### PR TITLE
TFP-4545 nye fri-koder og msp i egen flyt

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselDelregel.java
@@ -63,13 +63,6 @@ public class ForeldrepengerFørFødselDelregel implements RuleService<FastsetteP
         return rs.hvisRegel(SjekkOmForeldrepengerFørFødselStarterForTidligEllerSlutterForSent.ID, "Starter perioden for tidlig?")
                 .hvis(new SjekkOmForeldrepengerFørFødselStarterForTidligEllerSlutterForSent(konfigurasjon),
                         Manuellbehandling.opprett("UT1070", null, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO, true, false))
-                .ellers(sjekkOmManglendeSøktPeriodeNode(rs));
-    }
-
-    private Specification<FastsettePeriodeGrunnlag> sjekkOmManglendeSøktPeriodeNode(Ruleset<FastsettePeriodeGrunnlag> rs) {
-        return rs.hvisRegel(SjekkOmManglendeSøktPeriode.ID, "Er det manglende søkt periode?")
-                .hvis(new SjekkOmManglendeSøktPeriode(),
-                        IkkeOppfylt.opprett("UT1073", IkkeOppfyltÅrsak.MOR_TAR_IKKE_ALLE_UKENE, true, false))
                 .ellers(sjekkOmGradering(rs));
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktPeriodeDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktPeriodeDelregel.java
@@ -1,0 +1,97 @@
+package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
+
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBareFarHarRett;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBehandlingKreverSammenhengendeUttak;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmDagerIgjenPåAlleAktiviteter;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmPeriodeErForeldrepengerFørFødsel;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmPeriodenInnenforUkerReservertMor;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmTomForAlleSineKontoer;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfylt;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.Manuellbehandling;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.Manuellbehandlingårsak;
+import no.nav.foreldrepenger.regler.uttak.konfig.Konfigurasjon;
+import no.nav.fpsak.nare.RuleService;
+import no.nav.fpsak.nare.Ruleset;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.specification.Specification;
+
+/**
+ * Delregel innenfor regeltjenesten FastsettePeriodeRegel som fastsetter uttak av foreldrepenger før fødsel.
+ * <p>
+ * Utfall definisjoner:<br>
+ * <p>
+ * Utfall AVSLÅTT:<br>
+ * - Far søker om perioden
+ * - Perioden starter før perioden forbeholdt mor før fødsel.<br>
+ * - Perioden starter etter termin/fødsel.<br>
+ * <p>
+ * Utfall INNVILGET:<br>
+ * - Perioden dekker perioden forbeholdt mor før fødsel og det er mor som søker.
+ */
+
+@RuleDocumentation(value = ManglendeSøktPeriodeDelregel.ID, specificationReference = "https://confluence.adeo.no/display/MODNAV/1.+Samleside+for+oppdaterte+regelflyter")
+public class ManglendeSøktPeriodeDelregel implements RuleService<FastsettePeriodeGrunnlag> {
+
+    public static final String ID = "FP_VK 10.7.FRI";
+
+    private Konfigurasjon konfigurasjon;
+
+    public ManglendeSøktPeriodeDelregel() {
+        // For dokumentasjonsgenerering
+    }
+
+
+    ManglendeSøktPeriodeDelregel(Konfigurasjon konfigurasjon) {
+        this.konfigurasjon = konfigurasjon;
+    }
+
+    @Override
+    public Specification<FastsettePeriodeGrunnlag> getSpecification() {
+        return sjekkOmForeldrepengerFørFødsel(new Ruleset<>());
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmForeldrepengerFørFødsel(Ruleset<FastsettePeriodeGrunnlag> rs) {
+        return rs.hvisRegel(SjekkOmPeriodeErForeldrepengerFørFødsel.ID, "Er det Foreldrepenger før fødsel?")
+                .hvis(new SjekkOmPeriodeErForeldrepengerFørFødsel(),
+                        IkkeOppfylt.opprett("UT1073", IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_FØR_FØDSEL, true, false))
+                .ellers(sjekkOmTomPåAlleSineKonto(rs));
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmTomPåAlleSineKonto(Ruleset<FastsettePeriodeGrunnlag> rs) {
+        return rs.hvisRegel(SjekkOmTomForAlleSineKontoer.ID, SjekkOmTomForAlleSineKontoer.BESKRIVELSE)
+                .hvis(new SjekkOmTomForAlleSineKontoer(),
+                        IkkeOppfylt.opprett("UT1088", IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN, false, false))
+                .ellers(sjekkOmDagerIgjenPåAlleAktiviteter(rs));
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmDagerIgjenPåAlleAktiviteter(Ruleset<FastsettePeriodeGrunnlag> rs) {
+        return rs.hvisRegel(SjekkOmDagerIgjenPåAlleAktiviteter.ID, SjekkOmDagerIgjenPåAlleAktiviteter.BESKRIVELSE)
+                .hvis(new SjekkOmDagerIgjenPåAlleAktiviteter(), sjekkOmBrukSammenhengendeUttakÅrsaker(rs))
+                .ellers(Manuellbehandling.opprett("UT1291", null,
+                        Manuellbehandlingårsak.STØNADSKONTO_TOM, false, false));
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmBrukSammenhengendeUttakÅrsaker(Ruleset<FastsettePeriodeGrunnlag> rs) {
+        return rs.hvisRegel(SjekkOmBehandlingKreverSammenhengendeUttak.ID, SjekkOmBehandlingKreverSammenhengendeUttak.BESKRIVELSE)
+                .hvis(new SjekkOmBehandlingKreverSammenhengendeUttak(),
+                        IkkeOppfylt.opprett("UT1087", IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER, true, false))
+                .ellers(sjekkOmSakGjelderBareFarRett(rs));
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmSakGjelderBareFarRett(Ruleset<FastsettePeriodeGrunnlag> rs) {
+        return rs.hvisRegel(SjekkOmBareFarHarRett.ID, SjekkOmBareFarHarRett.BESKRIVELSE)
+                .hvis(new SjekkOmBareFarHarRett(),
+                        IkkeOppfylt.opprett("UT1093", IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT, true, false))
+                .ellers(sjekkOmPeriodeGjelderMorsReserverteUker(rs));
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmPeriodeGjelderMorsReserverteUker(Ruleset<FastsettePeriodeGrunnlag> rs) {
+        return rs.hvisRegel(SjekkOmPeriodenInnenforUkerReservertMor.ID, "Innenfor mors reserverte uker")
+                .hvis(new SjekkOmPeriodenInnenforUkerReservertMor(konfigurasjon),
+                        IkkeOppfylt.opprett("UT1094", IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL, true, false))
+                .ellers(Manuellbehandling.opprett("UT1095", null,
+                        Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO, true, false));
+    }
+
+}

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktPeriodeDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktPeriodeDelregel.java
@@ -17,17 +17,8 @@ import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.specification.Specification;
 
 /**
- * Delregel innenfor regeltjenesten FastsettePeriodeRegel som fastsetter uttak av foreldrepenger før fødsel.
- * <p>
- * Utfall definisjoner:<br>
- * <p>
- * Utfall AVSLÅTT:<br>
- * - Far søker om perioden
- * - Perioden starter før perioden forbeholdt mor før fødsel.<br>
- * - Perioden starter etter termin/fødsel.<br>
- * <p>
- * Utfall INNVILGET:<br>
- * - Perioden dekker perioden forbeholdt mor før fødsel og det er mor som søker.
+ * Delregel innenfor regeltjenesten FastsettePeriodeRegel som fastsetter perioder som ikke er søkt om.
+ * Disse er i hovedsak innenfor perioder som er reservert mor (14-9 sjette ledd) og tekniske trekkperioder for far (14-14 første ledd)
  */
 
 @RuleDocumentation(value = ManglendeSøktPeriodeDelregel.ID, specificationReference = "https://confluence.adeo.no/display/MODNAV/1.+Samleside+for+oppdaterte+regelflyter")

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/UtsettelseDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/UtsettelseDelregel.java
@@ -63,7 +63,7 @@ public class UtsettelseDelregel implements RuleService<FastsettePeriodeGrunnlag>
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmMorErIAktivitet() {
         return rs.hvisRegel(SjekkOmMorErIAktivitet.ID, SjekkOmMorErIAktivitet.BESKRIVELSE)
-                .hvis(new SjekkOmMorErIAktivitet(), Oppfylt.opprett("UT1352", InnvilgetÅrsak.UTSETTELSE_GYLDIG, false, false))
+                .hvis(new SjekkOmMorErIAktivitet(), Oppfylt.opprett("UT1352", InnvilgetÅrsak.UTSETTELSE_GYLDIG_BFR_AKT_KRAV_OPPFYLT, false, false))
                 .ellers(new AvslagAktivitetskravDelregel().getSpecification());
     }
 
@@ -75,8 +75,8 @@ public class UtsettelseDelregel implements RuleService<FastsettePeriodeGrunnlag>
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmSykdomSkade() {
         var erSøkerSykErDokumentert =  rs.hvisRegel(SjekkOmSykdomSkade.ID, SjekkOmSykdomSkade.BESKRIVELSE)
-                .hvis(new SjekkOmSykdomSkade(), Oppfylt.opprett("UT1353", InnvilgetÅrsak.UTSETTELSE_GYLDIG_PGA_SYKDOM, false, false))
-                .ellers(Manuellbehandling.opprett("UT1354", IkkeOppfyltÅrsak.SØKERS_SYKDOM_SKADE_IKKE_OPPFYLT,
+                .hvis(new SjekkOmSykdomSkade(), Oppfylt.opprett("UT1353", InnvilgetÅrsak.UTSETTELSE_GYLDIG_SEKS_UKER_FRI_SYKDOM, false, false))
+                .ellers(Manuellbehandling.opprett("UT1354", IkkeOppfyltÅrsak.SØKERS_SYKDOM_SKADE_SEKS_UKER_IKKE_OPPFYLT,
                         Manuellbehandlingårsak.IKKE_GYLDIG_GRUNN_FOR_UTSETTELSE, true, false));
         return rs.hvisRegel(SjekkOmUtsettelsePgaSykdomSkade.ID, SjekkOmUtsettelsePgaSykdomSkade.BESKRIVELSE)
                 .hvis(new SjekkOmUtsettelsePgaSykdomSkade(), erSøkerSykErDokumentert)
@@ -85,8 +85,8 @@ public class UtsettelseDelregel implements RuleService<FastsettePeriodeGrunnlag>
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmSøkersInnleggelse() {
         var erSøkerInnlagtErDokumentert =  rs.hvisRegel(SjekkOmSøkerInnlagt.ID, SjekkOmSøkerInnlagt.BESKRIVELSE)
-                .hvis(new SjekkOmSøkerInnlagt(), Oppfylt.opprett("UT1355", InnvilgetÅrsak.UTSETTELSE_GYLDIG_PGA_INNLEGGELSE, false, false))
-                .ellers(Manuellbehandling.opprett("UT1356", IkkeOppfyltÅrsak.SØKERS_INNLEGGELSE_IKKE_OPPFYLT,
+                .hvis(new SjekkOmSøkerInnlagt(), Oppfylt.opprett("UT1355", InnvilgetÅrsak.UTSETTELSE_GYLDIG_SEKS_UKER_INNLEGGELSE, false, false))
+                .ellers(Manuellbehandling.opprett("UT1356", IkkeOppfyltÅrsak.SØKERS_INNLEGGELSE_SEKS_UKER_IKKE_OPPFYLT,
                         Manuellbehandlingårsak.IKKE_GYLDIG_GRUNN_FOR_UTSETTELSE, true, false));
         return rs.hvisRegel(SjekkOmUtsettelsePgaSøkerInnleggelse.ID, SjekkOmUtsettelsePgaSøkerInnleggelse.BESKRIVELSE)
                 .hvis(new SjekkOmUtsettelsePgaSøkerInnleggelse(), erSøkerInnlagtErDokumentert)
@@ -103,7 +103,7 @@ public class UtsettelseDelregel implements RuleService<FastsettePeriodeGrunnlag>
     private Specification<FastsettePeriodeGrunnlag> sjekkOmBarnetVarInnlagt() {
         return rs.hvisRegel(SjekkOmBarnInnlagt.ID, SjekkOmBarnInnlagt.BESKRIVELSE)
                 .hvis(new SjekkOmBarnInnlagt(), sjekkOmFødselFørUke33())
-                .ellers(Manuellbehandling.opprett("UT1358", IkkeOppfyltÅrsak.BARNETS_INNLEGGELSE_IKKE_OPPFYLT,
+                .ellers(Manuellbehandling.opprett("UT1358", IkkeOppfyltÅrsak.BARNETS_INNLEGGELSE_SEKS_UKER_IKKE_OPPFYLT,
                         Manuellbehandlingårsak.IKKE_GYLDIG_GRUNN_FOR_UTSETTELSE, true, false));
     }
 
@@ -122,6 +122,6 @@ public class UtsettelseDelregel implements RuleService<FastsettePeriodeGrunnlag>
     }
 
     private FastsettePeriodeUtfall innvilgUT1359() {
-        return Oppfylt.opprett("UT1359", InnvilgetÅrsak.UTSETTELSE_GYLDIG_PGA_BARN_INNLAGT, false, false);
+        return Oppfylt.opprett("UT1359", InnvilgetÅrsak.UTSETTELSE_GYLDIG_SEKS_UKER_FRI_BARN_INNLAGT, false, false);
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/IkkeOppfyltÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/IkkeOppfyltÅrsak.java
@@ -14,7 +14,9 @@ public enum IkkeOppfyltÅrsak implements PeriodeResultatÅrsak {
     OPPHOLD_IKKE_SAMTIDIG_UTTAK(4084, "Opphold på grunn av den andre forelderens vedtak"),
     IKKE_SAMTYKKE(4085, "Ikke samtykke mellom foreldrene"),
     OPPHOLD_UTSETTELSE(4086, "Opphold på grunn av den andre forelderens vedtak"),
-    MOR_TAR_IKKE_ALLE_UKENE(4095, "Mor tar ikke alle ukene"),
+    MOR_TAR_IKKE_UKENE_FØR_FØDSEL(4095, "Mor tar ikke alle ukene før fødsel"),
+    MOR_TAR_IKKE_UKENE_ETTER_FØDSEL(4103, "Mor tar ikke alle ukene etter fødsel"),
+    BARE_FAR_RETT_IKKE_SØKT(4102, "Bare far rett ikke-søkt periode"),
     SØKER_DØD(4071, "Søker er død"),
     BARN_DØD(4072, "Barnet er dødt"),
     MOR_IKKE_RETT_FK(4073, "Ikke rett til kvote fordi mor ikke har rett til foreldrepenger"),
@@ -43,6 +45,10 @@ public enum IkkeOppfyltÅrsak implements PeriodeResultatÅrsak {
     SØKT_GRADERING_ETTER_PERIODEN_HAR_BEGYNT(4080, "Søker har søkt om gradert uttak etter at perioden med delvis arbeid er påbegynt"),
     SØKT_UTSETTELSE_FERIE_ETTER_PERIODEN_HAR_BEGYNT(4081, "Søker har søkt om utsettelse pga ferie etter ferien er begynt"),
     SØKT_UTSETTELSE_ARBEID_ETTER_PERIODEN_HAR_BEGYNT(4082, "Søker har søkt om utsettelse pga arbeid etter arbeid er begynt"),
+
+    SØKERS_SYKDOM_SKADE_SEKS_UKER_IKKE_OPPFYLT(4110, "Søkers sykdom/skade første 6 uker ikke oppfylt"),
+    SØKERS_INNLEGGELSE_SEKS_UKER_IKKE_OPPFYLT(4111, "Søkers innleggelse første 6 uker ikke oppfylt"),
+    BARNETS_INNLEGGELSE_SEKS_UKER_IKKE_OPPFYLT(4112, "Barnets innleggelse første 6 uker ikke oppfylt"),
 
     //Medlem
     SØKER_IKKE_MEDLEM(4087, "Søker ikke medlem"),

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/InnvilgetÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/InnvilgetÅrsak.java
@@ -29,7 +29,11 @@ public enum InnvilgetÅrsak implements PeriodeResultatÅrsak {
     UTSETTELSE_GYLDIG_PGA_SYKDOM(2014, "Utsettelse pga sykdom"),
 
 
-    UTSETTELSE_GYLDIG(2024, "Gyldig utsettelse")
+    UTSETTELSE_GYLDIG(2024, "Gyldig utsettelse"),
+    UTSETTELSE_GYLDIG_SEKS_UKER_INNLEGGELSE(2025, "Gyldig utsettelse første 6 uker pga. innleggelse"),
+    UTSETTELSE_GYLDIG_SEKS_UKER_FRI_BARN_INNLAGT(2026, "Gyldig utsettelse første 6 uker pga. barn innlagt"),
+    UTSETTELSE_GYLDIG_SEKS_UKER_FRI_SYKDOM(2027, "Gyldig utsettelse første 6 uker pga. sykdom"),
+    UTSETTELSE_GYLDIG_BFR_AKT_KRAV_OPPFYLT(2028, "Gyldig utsettelse aktivitetskrav oppfylt "),
     ;
 
     private final int id;

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeOrkestreringTest.java
@@ -142,7 +142,7 @@ class FellesperiodeOrkestreringTest extends FastsettePerioderRegelOrkestreringTe
 
         assertThat(resultater).hasSize(3);
         verifiserAvslåttPeriode(resultater.get(0).getUttakPeriode(), fødselsdato, fødselsdato.plusWeeks(3).minusDays(3), MØDREKVOTE,
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
         verifiserManuellBehandlingPeriode(resultater.get(1).getUttakPeriode(), fødselsdato.plusWeeks(3),
                 fødselsdato.plusWeeks(6).minusDays(1), FELLESPERIODE, null, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO);
         verifiserPeriode(resultater.get(2).getUttakPeriode(), fødselsdato.plusWeeks(6), fødselsdato.plusWeeks(10).minusDays(1),
@@ -169,7 +169,7 @@ class FellesperiodeOrkestreringTest extends FastsettePerioderRegelOrkestreringTe
         verifiserManuellBehandlingPeriode(resultater.get(3).getUttakPeriode(), fødselsdato, fødselsdato, FELLESPERIODE, null,
                 Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO);
         verifiserAvslåttPeriode(resultater.get(4).getUttakPeriode(), fødselsdato.plusDays(1), fødselsdato.plusWeeks(6).minusDays(3),
-                MØDREKVOTE, IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                MØDREKVOTE, IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
     }
 
     @Test

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselDelregelTest.java
@@ -83,7 +83,7 @@ class ForeldrepengerFørFødselDelregelTest {
         assertThat(regelresultat.oppfylt()).isFalse();
         assertThat(regelresultat.skalUtbetale()).isFalse();
         assertThat(regelresultat.trekkDagerFraSaldo()).isTrue();
-        assertThat(regelresultat.getAvklaringÅrsak()).isEqualTo(IkkeOppfyltÅrsak.MOR_TAR_IKKE_ALLE_UKENE);
+        assertThat(regelresultat.getAvklaringÅrsak()).isEqualTo(IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_FØR_FØDSEL);
     }
 
     @Test

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselOrkestreringTest.java
@@ -90,7 +90,7 @@ class ForeldrepengerFørFødselOrkestreringTest extends FastsettePerioderRegelOr
         assertThat(perioder.get(2).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
         assertThat(perioder.get(2).getUttakPeriode().getStønadskontotype()).isEqualTo(Stønadskontotype.MØDREKVOTE);
         assertThat(perioder.get(2).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
         assertThat(perioder.get(2).getUttakPeriode().getFom()).isEqualTo(fødselsdato);
         assertThat(perioder.get(2).getUttakPeriode().getTom()).isEqualTo(fødselsdato.plusWeeks(6).minusDays(3));
         assertThat(perioder.get(2).getInnsendtGrunnlag()).isNotNull();
@@ -175,7 +175,7 @@ class ForeldrepengerFørFødselOrkestreringTest extends FastsettePerioderRegelOr
         assertThat(perioder.get(3).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
         assertThat(perioder.get(3).getUttakPeriode().getStønadskontotype()).isEqualTo(Stønadskontotype.MØDREKVOTE);
         assertThat(perioder.get(3).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
         assertThat(perioder.get(3).getUttakPeriode().getFom()).isEqualTo(fødselsdato);
         assertThat(perioder.get(3).getUttakPeriode().getTom()).isEqualTo(fødselsdato.plusWeeks(6).minusDays(1));
         assertThat(perioder.get(3).getInnsendtGrunnlag()).isNotNull();
@@ -202,7 +202,7 @@ class ForeldrepengerFørFødselOrkestreringTest extends FastsettePerioderRegelOr
 
         assertThat(perioder.get(1).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
         assertThat(perioder.get(1).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
         assertThat(perioder.get(1).getUttakPeriode().getStønadskontotype()).isEqualTo(Stønadskontotype.MØDREKVOTE);
         assertThat(perioder.get(1).getUttakPeriode().getFom()).isEqualTo(fødselsdato);
         assertThat(perioder.get(1).getUttakPeriode().getTom()).isEqualTo(fødselsdato.plusWeeks(6).minusDays(3));

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktOrkestreringTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeid;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeidsforhold;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Behandling;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Datoer;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Dokumentasjon;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode;
@@ -43,8 +42,7 @@ class ManglendeSøktOrkestreringTest extends FastsettePerioderRegelOrkestreringT
                 .rettOgOmsorg(bareFarRett())
                 .build();
         var perioder = fastsettPerioder(grunnlag);
-
-        //TODO fritt uttak: Manuell behandling for alle manglende søkt
+        
         assertThat(perioder).hasSize(3);
         assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
                 IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT);

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktOrkestreringTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeid;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeidsforhold;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Behandling;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Datoer;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Dokumentasjon;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode;
@@ -46,13 +47,13 @@ class ManglendeSøktOrkestreringTest extends FastsettePerioderRegelOrkestreringT
         //TODO fritt uttak: Manuell behandling for alle manglende søkt
         assertThat(perioder).hasSize(3);
         assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT);
         assertThat(perioder.get(0).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
         assertThat(perioder.get(0).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).merEnn0()).isTrue();
         assertThat(perioder.get(0).getUttakPeriode().getStønadskontotype()).isEqualTo(FORELDREPENGER);
 
         assertThat(perioder.get(1).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN);
         assertThat(perioder.get(1).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
         assertThat(perioder.get(1).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).merEnn0()).isFalse();
         assertThat(perioder.get(1).getUttakPeriode().getStønadskontotype()).isEqualTo(FORELDREPENGER);
@@ -102,7 +103,7 @@ class ManglendeSøktOrkestreringTest extends FastsettePerioderRegelOrkestreringT
         var perioder = fastsettPerioder(grunnlag);
 
         assertThat(perioder).hasSize(3);
-        assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT);
         //UT1291
         assertThat(perioder.get(1).isManuellBehandling()).isTrue();
     }
@@ -134,7 +135,7 @@ class ManglendeSøktOrkestreringTest extends FastsettePerioderRegelOrkestreringT
         assertThat(perioder).hasSize(3);
 
         assertThat(perioder.get(0).getUttakPeriode().getPerioderesultattype()).isEqualTo(AVSLÅTT);
-        assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT);
         assertThat(perioder.get(0).getUttakPeriode().getStønadskontotype()).isEqualTo(FORELDREPENGER);
         assertThat(perioder.get(0).getUttakPeriode().getAktiviteter()).hasSize(1);
         assertThat(perioder.get(0).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD))
@@ -143,7 +144,7 @@ class ManglendeSøktOrkestreringTest extends FastsettePerioderRegelOrkestreringT
         assertThat(perioder.get(0).getUttakPeriode().getTom()).isEqualTo(startdatoNyttArbeidsforhold.minusDays(1));
 
         assertThat(perioder.get(1).getUttakPeriode().getPerioderesultattype()).isEqualTo(AVSLÅTT);
-        assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT);
         assertThat(perioder.get(1).getUttakPeriode().getStønadskontotype()).isEqualTo(FORELDREPENGER);
         assertThat(perioder.get(1).getUttakPeriode().getAktiviteter()).hasSize(2);
         assertThat(perioder.get(1).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD)).isEqualTo(new Trekkdager(5));

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktSammenhengendeUttakOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ManglendeSøktSammenhengendeUttakOrkestreringTest.java
@@ -1,21 +1,29 @@
 package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
 
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedAvklartMorsAktivitet.Resultat.I_AKTIVITET;
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.AVSLÅTT;
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknadstype.FØDSEL;
+import static no.nav.foreldrepenger.regler.uttak.felles.grunnlag.Stønadskontotype.FORELDREPENGER;
+import static no.nav.foreldrepenger.regler.uttak.felles.grunnlag.Stønadskontotype.FORELDREPENGER_FØR_FØDSEL;
+import static no.nav.foreldrepenger.regler.uttak.felles.grunnlag.Stønadskontotype.MØDREKVOTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktivitetIdentifikator;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeid;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeidsforhold;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Behandling;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Datoer;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Dokumentasjon;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriodeAktivitet;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.GyldigGrunnPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Konto;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Kontoer;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Orgnummer;
@@ -28,6 +36,8 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknadstype
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Utbetalingsgrad;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Vedtak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.InnvilgetÅrsak;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.Manuellbehandlingårsak;
 import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.Stønadskontotype;
 
 class ManglendeSøktSammenhengendeUttakOrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
@@ -109,7 +119,7 @@ class ManglendeSøktSammenhengendeUttakOrkestreringTest extends FastsettePeriode
 
         assertThat(perioder).hasSize(4);
         assertThat(perioder.get(2).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN);
         assertThat(perioder.get(2).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
         assertThat(perioder.get(2).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).decimalValue()).isZero();
         assertThat(perioder.get(2).getUttakPeriode().getStønadskontotype()).isNull();
@@ -136,7 +146,7 @@ class ManglendeSøktSammenhengendeUttakOrkestreringTest extends FastsettePeriode
         assertThat(perioder.get(2).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).decimalValue()).isNotZero();
         assertThat(perioder.get(2).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
         assertThat(perioder.get(3).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN);
         assertThat(perioder.get(3).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
         assertThat(perioder.get(3).getUttakPeriode().getStønadskontotype()).isNull();
         assertThat(perioder.get(3).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).decimalValue()).isZero();
@@ -171,7 +181,7 @@ class ManglendeSøktSammenhengendeUttakOrkestreringTest extends FastsettePeriode
         assertThat(perioder.get(3).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).decimalValue()).isNotZero();
         assertThat(perioder.get(3).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
         assertThat(perioder.get(4).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
-                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+                IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN);
         assertThat(perioder.get(4).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
         assertThat(perioder.get(4).getUttakPeriode().getStønadskontotype()).isNull();
         assertThat(perioder.get(4).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).decimalValue()).isZero();
@@ -273,4 +283,180 @@ class ManglendeSøktSammenhengendeUttakOrkestreringTest extends FastsettePeriode
         assertThat(perioder.get(5).getUttakPeriode().getTom()).isEqualTo(fødselsdato.plusWeeks(15).minusDays(1));
     }
 
+    @Test
+    void skal_avslå_og_trekke_foreldrepenger_for_bare_far_har_rett_hvis_dager_igjen_regresjon() {
+        var fødselsdato = LocalDate.of(2019, 9, 3);
+        var grunnlag = basicGrunnlagFarSammenhengendeUttak(fødselsdato).søknad(søknad(FØDSEL,
+                oppgittPeriode(FORELDREPENGER, fødselsdato.plusWeeks(50), fødselsdato.plusWeeks(52))))
+                .kontoer(kontoer(konto(FORELDREPENGER, 100)))
+                .rettOgOmsorg(bareFarRett())
+                .build();
+        var perioder = fastsettPerioder(grunnlag);
+
+        assertThat(perioder).hasSize(3);
+        assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
+                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(perioder.get(0).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(perioder.get(0).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).merEnn0()).isTrue();
+        assertThat(perioder.get(0).getUttakPeriode().getStønadskontotype()).isEqualTo(FORELDREPENGER);
+
+        assertThat(perioder.get(1).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
+                IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN);
+        assertThat(perioder.get(1).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(perioder.get(1).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).merEnn0()).isFalse();
+        assertThat(perioder.get(1).getUttakPeriode().getStønadskontotype()).isEqualTo(FORELDREPENGER);
+
+        assertThat(perioder.get(2).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
+                IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN);
+        assertThat(perioder.get(2).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(perioder.get(2).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).merEnn0()).isFalse();
+        assertThat(perioder.get(2).getUttakPeriode().getStønadskontotype()).isEqualTo(FORELDREPENGER);
+    }
+
+    @Test
+    void delvisUgyldigUtsattMødrekvote() {
+        var fødselsdato = LocalDate.of(2018, 1, 8);
+        var gyldigUtsettelseStart = fødselsdato.plusDays(5);
+        var gyldigUtsettelseSlutt = fødselsdato.plusDays(10);
+
+        var søknad = new Søknad.Builder()
+                .oppgittPeriode(oppgittPeriode(FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1)))
+                .oppgittPeriode(oppgittPeriode(MØDREKVOTE, gyldigUtsettelseSlutt.plusDays(1), fødselsdato.plusWeeks(6).minusDays(1)))
+                .dokumentasjon(new Dokumentasjon.Builder().gyldigGrunnPeriode(new GyldigGrunnPeriode(gyldigUtsettelseStart, gyldigUtsettelseSlutt)));
+        var grunnlag = basicGrunnlagMorSammenhengendeUttak(fødselsdato)
+                .datoer(datoer(fødselsdato))
+                .rettOgOmsorg(beggeRett())
+                .søknad(søknad);
+
+        var resultat = fastsettPerioder(grunnlag);
+        var uttakPerioder = resultat.stream().map(FastsettePeriodeResultat::getUttakPeriode).collect(Collectors.toList());
+
+        assertThat(uttakPerioder).hasSize(4);
+
+        // Første del av msp blir manuell behandling
+        var ugyldigUtsattPeriode = uttakPerioder.get(1);
+        assertThat(ugyldigUtsattPeriode.getPerioderesultattype()).isEqualTo(AVSLÅTT);
+        assertThat(ugyldigUtsattPeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(ugyldigUtsattPeriode.getFom()).isEqualTo(fødselsdato);
+        assertThat(ugyldigUtsattPeriode.getTom()).isEqualTo(fødselsdato.plusDays(4));
+        assertThat(ugyldigUtsattPeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);
+
+        var gyldigUtsattPeriode = uttakPerioder.get(2);
+        assertThat(gyldigUtsattPeriode.getPerioderesultattype()).isEqualTo(AVSLÅTT);
+        assertThat(gyldigUtsattPeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(gyldigUtsattPeriode.getFom()).isEqualTo(gyldigUtsettelseStart);
+        assertThat(gyldigUtsattPeriode.getTom()).isEqualTo(gyldigUtsettelseSlutt);
+        assertThat(gyldigUtsattPeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);
+
+        var innvilgetUttakPeriode = uttakPerioder.get(3);
+        assertThat(innvilgetUttakPeriode.getPerioderesultattype()).isEqualTo(Perioderesultattype.INNVILGET);
+        assertThat(innvilgetUttakPeriode.getManuellbehandlingårsak()).isNull();
+        assertThat(innvilgetUttakPeriode.getFom()).isEqualTo(gyldigUtsettelseSlutt.plusDays(1));
+        assertThat(innvilgetUttakPeriode.getTom()).isEqualTo(fødselsdato.plusWeeks(6).minusDays(1));
+        assertThat(innvilgetUttakPeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);
+    }
+
+   private Datoer.Builder datoer(LocalDate fødselsdato) {
+       return new Datoer.Builder().fødsel(fødselsdato);
+   }
+
+    @Test
+    void mødrekvoteMedUtsattOppstartUtenGyldigGrunnSkalTrekkeDagerPåSaldo() {
+        var fødselsdato = LocalDate.of(2018, 1, 8);
+        var sluttGyldigUtsattPeriode = fødselsdato.plusDays(6);
+        var startUgyldigPeriode = fødselsdato.plusDays(7);
+        var sluttUgyldigPeriode = startUgyldigPeriode.plusDays(4);
+
+        var grunnlag = basicGrunnlagMorSammenhengendeUttak(fødselsdato)
+                .datoer(datoer(fødselsdato))
+                .rettOgOmsorg(beggeRett())
+                .søknad(new Søknad.Builder().oppgittPeriode(
+                        oppgittPeriode(FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1)))
+                        .oppgittPeriode(
+                                oppgittPeriode(MØDREKVOTE, sluttUgyldigPeriode.plusDays(1), sluttUgyldigPeriode.plusWeeks(10)))
+                        .dokumentasjon(new Dokumentasjon.Builder().gyldigGrunnPeriode(
+                                new GyldigGrunnPeriode(fødselsdato, sluttGyldigUtsattPeriode))));
+
+        var fastsettePeriodeGrunnlag = grunnlag.build();
+        var resultat = fastsettPerioder(fastsettePeriodeGrunnlag);
+        var uttakPerioder = resultat.stream().map(FastsettePeriodeResultat::getUttakPeriode).collect(Collectors.toList());
+        assertThat(uttakPerioder).hasSize(6);
+
+        /* FPFF blir innvilget. */
+        var foreldrepengerFørFødselPeriode = uttakPerioder.get(0);
+        assertThat(foreldrepengerFørFødselPeriode.getFom()).isEqualTo(fødselsdato.minusWeeks(3));
+        assertThat(foreldrepengerFørFødselPeriode.getTom()).isEqualTo(fødselsdato.minusDays(1));
+        assertThat(foreldrepengerFørFødselPeriode.getPerioderesultattype()).isEqualTo(Perioderesultattype.INNVILGET);
+        assertThat(foreldrepengerFørFødselPeriode.getStønadskontotype()).isEqualTo(FORELDREPENGER_FØR_FØDSEL);
+
+
+        /* Første del av opphold-perioden er gyldig utsettelse, men skal likevel behandles manuelt. */
+        var gyldigUtsettelsePeriode = uttakPerioder.get(1);
+        assertThat(gyldigUtsettelsePeriode.getTom()).isEqualTo(sluttGyldigUtsattPeriode);
+        assertThat(gyldigUtsettelsePeriode.getFom()).isEqualTo(fødselsdato);
+        assertThat(gyldigUtsettelsePeriode.getPerioderesultattype()).isEqualTo(AVSLÅTT);
+        assertThat(gyldigUtsettelsePeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);
+        assertThat(gyldigUtsettelsePeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+
+
+        var ugyldigUtsettelsePeriode = uttakPerioder.get(2);
+        assertThat(ugyldigUtsettelsePeriode.getFom()).isEqualTo(sluttGyldigUtsattPeriode.plusDays(1));
+        assertThat(ugyldigUtsettelsePeriode.getTom()).isEqualTo(sluttUgyldigPeriode);
+        assertThat(ugyldigUtsettelsePeriode.getPerioderesultattype()).isEqualTo(AVSLÅTT);
+        assertThat(ugyldigUtsettelsePeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);
+        assertThat(ugyldigUtsettelsePeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+
+        /* Splittes ved knekkpunkt ved 6 uker pga regelflyt */
+        var uttakPeriode1 = uttakPerioder.get(3);
+        assertThat(uttakPeriode1.getPerioderesultattype()).isEqualTo(Perioderesultattype.INNVILGET);
+        assertThat(uttakPeriode1.getStønadskontotype()).isEqualTo(MØDREKVOTE);
+        assertThat(uttakPeriode1.getFom()).isEqualTo(sluttUgyldigPeriode.plusDays(1));
+        assertThat(uttakPeriode1.getTom()).isEqualTo(fødselsdato.plusWeeks(6).minusDays(1));
+        assertThat(uttakPeriode1.getManuellbehandlingårsak()).isNull();
+
+        var uttakPeriode2 = uttakPerioder.get(4);
+        assertThat(uttakPeriode2.getPerioderesultattype()).isEqualTo(Perioderesultattype.INNVILGET);
+        assertThat(uttakPeriode2.getStønadskontotype()).isEqualTo(MØDREKVOTE);
+        assertThat(uttakPeriode2.getFom()).isEqualTo(fødselsdato.plusWeeks(6));
+        assertThat(uttakPeriode2.getTom()).isEqualTo(sluttUgyldigPeriode.plusWeeks(8).plusDays(2));
+        assertThat(uttakPeriode2.getManuellbehandlingårsak()).isNull();
+
+        //Det er tom for konto for siste del siden allerede trekk fra saldo for forrige perioder
+        // (gyldigutsett + ugyldigutsett) som gikk til manuell behandling
+        var uttakPeriode3 = uttakPerioder.get(5);
+        assertThat(uttakPeriode3.getPerioderesultattype()).isEqualTo(Perioderesultattype.MANUELL_BEHANDLING);
+        assertThat(uttakPeriode3.getStønadskontotype()).isEqualTo(MØDREKVOTE);
+        assertThat(uttakPeriode3.getFom()).isEqualTo(sluttUgyldigPeriode.plusWeeks(8).plusDays(3));
+        assertThat(uttakPeriode3.getTom()).isEqualTo(sluttUgyldigPeriode.plusWeeks(10));
+        assertThat(uttakPeriode3.getManuellbehandlingårsak()).isEqualTo(Manuellbehandlingårsak.STØNADSKONTO_TOM);
+    }
+
+    @Test
+    void foreldrepengerFørFødsel_for_kort_fpff_starter_for_sent() {
+        var fødselsdato = LocalDate.of(2018, 1, 1);
+        basicGrunnlagMorSammenhengendeUttak(fødselsdato).søknad(søknad(Søknadstype.FØDSEL,
+                oppgittPeriode(Stønadskontotype.FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(1), fødselsdato.minusDays(1))));
+        var perioder = fastsettPerioder(grunnlag);
+
+        assertThat(perioder).hasSize(2);
+
+        assertThat(perioder.get(0).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.INNVILGET);
+        assertThat(perioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(InnvilgetÅrsak.FORELDREPENGER_FØR_FØDSEL);
+        assertThat(perioder.get(0).getUttakPeriode().getStønadskontotype()).isEqualTo(Stønadskontotype.FORELDREPENGER_FØR_FØDSEL);
+        assertThat(perioder.get(0).getUttakPeriode().getFom()).isEqualTo(fødselsdato.minusWeeks(1));
+        assertThat(perioder.get(0).getUttakPeriode().getTom()).isEqualTo(fødselsdato.minusDays(1));
+        assertThat(perioder.get(0).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD)).isEqualTo(new Trekkdager(5));
+        assertThat(perioder.get(0).getInnsendtGrunnlag()).isNotNull();
+        assertThat(perioder.get(0).getEvalueringResultat()).isNotNull();
+
+        assertThat(perioder.get(1).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
+        assertThat(perioder.get(1).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(
+                IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(perioder.get(1).getUttakPeriode().getStønadskontotype()).isEqualTo(Stønadskontotype.MØDREKVOTE);
+        assertThat(perioder.get(1).getUttakPeriode().getFom()).isEqualTo(fødselsdato);
+        assertThat(perioder.get(1).getUttakPeriode().getTom()).isEqualTo(fødselsdato.plusWeeks(6).minusDays(3));
+        assertThat(perioder.get(1).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD)).isEqualTo(new Trekkdager(30));
+        assertThat(perioder.get(1).getInnsendtGrunnlag()).isNotNull();
+        assertThat(perioder.get(1).getEvalueringResultat()).isNotNull();
+    }
 }

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/OrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/OrkestreringTest.java
@@ -158,7 +158,7 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
         assertThat(gyldigUtsettelsePeriode.getFom()).isEqualTo(fødselsdato);
         assertThat(gyldigUtsettelsePeriode.getPerioderesultattype()).isEqualTo(AVSLÅTT);
         assertThat(gyldigUtsettelsePeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);
-        assertThat(gyldigUtsettelsePeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(gyldigUtsettelsePeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
 
 
         var ugyldigUtsettelsePeriode = uttakPerioder.get(2);
@@ -166,7 +166,7 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
         assertThat(ugyldigUtsettelsePeriode.getTom()).isEqualTo(sluttUgyldigPeriode);
         assertThat(ugyldigUtsettelsePeriode.getPerioderesultattype()).isEqualTo(AVSLÅTT);
         assertThat(ugyldigUtsettelsePeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);
-        assertThat(ugyldigUtsettelsePeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(ugyldigUtsettelsePeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
 
         /* Splittes ved knekkpunkt ved 6 uker pga regelflyt */
         var uttakPeriode1 = uttakPerioder.get(3);
@@ -216,14 +216,14 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
         // Første del av msp blir manuell behandling
         var ugyldigUtsattPeriode = uttakPerioder.get(1);
         assertThat(ugyldigUtsattPeriode.getPerioderesultattype()).isEqualTo(AVSLÅTT);
-        assertThat(ugyldigUtsattPeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(ugyldigUtsattPeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
         assertThat(ugyldigUtsattPeriode.getFom()).isEqualTo(fødselsdato);
         assertThat(ugyldigUtsattPeriode.getTom()).isEqualTo(fødselsdato.plusDays(4));
         assertThat(ugyldigUtsattPeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);
 
         var gyldigUtsattPeriode = uttakPerioder.get(2);
         assertThat(gyldigUtsattPeriode.getPerioderesultattype()).isEqualTo(AVSLÅTT);
-        assertThat(gyldigUtsattPeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER);
+        assertThat(gyldigUtsattPeriode.getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.MOR_TAR_IKKE_UKENE_ETTER_FØDSEL);
         assertThat(gyldigUtsattPeriode.getFom()).isEqualTo(gyldigUtsettelseStart);
         assertThat(gyldigUtsattPeriode.getTom()).isEqualTo(gyldigUtsettelseSlutt);
         assertThat(gyldigUtsattPeriode.getStønadskontotype()).isEqualTo(MØDREKVOTE);

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/UtsettelseOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/UtsettelseOrkestreringTest.java
@@ -471,7 +471,9 @@ class UtsettelseOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
         assertThat(manuellPeriode.getPerioderesultattype()).isEqualTo(Perioderesultattype.MANUELL_BEHANDLING);
     }
 
-    @Disabled("TODO fritt uttak. Hvilke caser kan må gå tom for dager ved avslag utsettelse? Kanskje bare far har rett og utsettelse uten årsak")
+    // TODO fritt uttak. Hvilke caser kan må gå tom for dager ved avslag utsettelse?
+    //  Kanskje bare far har rett og utsettelse uten årsak
+    // Vurder saldosjekk i aktivitetskravflyt så man får tom på konto
     @Test
     void avslag_utsettelse_med_trekkdager_skal_knekkes_når_saldo_går_tom() {
         var fødselsdato = LocalDate.of(2021, 1, 20);
@@ -482,7 +484,7 @@ class UtsettelseOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
                 new PeriodeMedAvklartMorsAktivitet(fom, tom, PeriodeMedAvklartMorsAktivitet.Resultat.IKKE_I_AKTIVITET_DOKUMENTERT));
         //Skal gå tom for dager
         var utsettelse = OppgittPeriode.forUtsettelse(fom, tom, PeriodeVurderingType.PERIODE_OK,
-                ARBEID, fødselsdato, fødselsdato, MorsAktivitet.ARBEID);
+                FRI, fødselsdato, fødselsdato, MorsAktivitet.ARBEID);
         basicGrunnlagFar(fødselsdato)
                 .datoer(new Datoer.Builder().fødsel(fødselsdato))
                 .rettOgOmsorg(bareFarRett())
@@ -502,7 +504,7 @@ class UtsettelseOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
 
         assertThat(perioder.get(1).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
         assertThat(perioder.get(1).getUttakPeriode().getPeriodeResultatÅrsak())
-                .isEqualTo(IkkeOppfyltÅrsak.INGEN_STØNADSDAGER_IGJEN_FOR_AVSLÅTT_UTSETTELSE);
+                .isEqualTo(IkkeOppfyltÅrsak.AKTIVITETSKRAVET_ARBEID_IKKE_OPPFYLT);
         assertThat(perioder.get(1).getUttakPeriode().getFom()).isEqualTo(fom.plusWeeks(2));
         assertThat(perioder.get(1).getUttakPeriode().getTom()).isEqualTo(tom);
         assertThat(perioder.get(1).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
@@ -538,8 +540,6 @@ class UtsettelseOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
         assertThat(perioder.get(0).getUttakPeriode().getUtbetalingsgrad(ARBEIDSFORHOLD)).isEqualTo(Utbetalingsgrad.ZERO);
         assertThat(perioder.get(0).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD).merEnn0()).isFalse();
     }
-
-    //TODO fritt uttak. Lage tester på bare far har rett. Avhenger av om det løses med utsettelse uten årsak eller ikke
 
     private Datoer.Builder datoer(LocalDate fødselsdato) {
         return new Datoer.Builder().fødsel(fødselsdato);


### PR DESCRIPTION
Nye koder 2025-8 + 4102-3 + 4110-17 
Skilt ut MSP som egen flyt og justert årsaker på div regler, slik som UT1088. Fjerne 1084+6
Duplisert noen tester for regresjonsformål. Laget en innledende BFHR-test for fri utsettelse/2028