### PR TITLE
TFP-4557 koherent ikkeoppfylt+manuellårsak far før fødsel

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregel.java
@@ -182,8 +182,8 @@ public class FedrekvoteDelregel implements RuleService<FastsettePeriodeGrunnlag>
     private Specification<FastsettePeriodeGrunnlag> uttakFørTerminFødsel() {
         return rs.hvisRegel(SjekkOmPeriodenSlutterFørFamiliehendelse.ID, "Skal uttaksperioden være før termin/fødsel?")
                 .hvis(new SjekkOmPeriodenSlutterFørFamiliehendelse(),
-                        Manuellbehandling.opprett("UT1020", IkkeOppfyltÅrsak.FAR_HAR_IKKE_OMSORG,
-                                Manuellbehandlingårsak.SØKER_HAR_IKKE_OMSORG, false, false))
+                        Manuellbehandling.opprett("UT1020", IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
+                                Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL, false, false))
                 .ellers(sjekkOmPeriodenGjelderFlerbarnsdager());
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeDelregel.java
@@ -177,8 +177,8 @@ public class FellesperiodeDelregel implements RuleService<FastsettePeriodeGrunnl
     private Specification<FastsettePeriodeGrunnlag> sjekkOmPeriodenSlutterFørFamiliehendelse() {
         return rs.hvisRegel(SjekkOmPeriodenSlutterFørFamiliehendelse.ID, "Skal uttaksperioden være før termin/fødsel?")
                 .hvis(new SjekkOmPeriodenSlutterFørFamiliehendelse(),
-                        Manuellbehandling.opprett("UT1049", IkkeOppfyltÅrsak.FAR_HAR_IKKE_OMSORG,
-                                Manuellbehandlingårsak.SØKER_HAR_IKKE_OMSORG, false, false))
+                        Manuellbehandling.opprett("UT1049", IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
+                                Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL, false, false))
                 .ellers(sjekkOmPeriodenGjelderFlerbarnsdager());
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
@@ -184,8 +184,8 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakSkalVæreFørFamileHendelse() {
         return rs.hvisRegel(SjekkOmPeriodenSlutterFørFamiliehendelse.ID, "Skal uttak være før termin/fødsel?")
                 .hvis(new SjekkOmPeriodenSlutterFørFamiliehendelse(),
-                        Manuellbehandling.opprett("UT1193", IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER,
-                                Manuellbehandlingårsak.SØKER_HAR_IKKE_OMSORG, false, false))
+                        Manuellbehandling.opprett("UT1193", IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
+                                Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL, false, false))
                 .ellers(sjekkErDetAleneomsorgFar());
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselDelregel.java
@@ -53,8 +53,8 @@ public class ForeldrepengerFørFødselDelregel implements RuleService<FastsetteP
     private Specification<FastsettePeriodeGrunnlag> sjekkOmSøkerErMorNode(Ruleset<FastsettePeriodeGrunnlag> rs) {
         return rs.hvisRegel(SjekkOmSøkerErMor.ID, "Er søker mor?")
                 .hvis(new SjekkOmSøkerErMor(), sjekkOmPeriodenStarterForTidligNode(rs))
-                .ellers(Manuellbehandling.opprett("UT1076", IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER,
-                        Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO, false, false));
+                .ellers(Manuellbehandling.opprett("UT1076", IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
+                        Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL, false, false));
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmPeriodenStarterForTidligNode(Ruleset<FastsettePeriodeGrunnlag> rs) {

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/IkkeOppfyltÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/IkkeOppfyltÅrsak.java
@@ -21,7 +21,7 @@ public enum IkkeOppfyltÅrsak implements PeriodeResultatÅrsak {
     BARN_DØD(4072, "Barnet er dødt"),
     MOR_IKKE_RETT_FK(4073, "Ikke rett til kvote fordi mor ikke har rett til foreldrepenger"),
     MOR_IKKE_RETT_FP(4075, "Ikke rett til fellesperiode fordi mor ikke har rett til foreldrepenger"),
-    FAR_PERIODE_FØR_FØDSEL(4105, "Andre parten søker uttak før fødsel/omsorg"),
+    FAR_PERIODE_FØR_FØDSEL(4105, "Far/medmor søker uttak før fødsel/omsorg"),
 
     // Adopsjon
     FØR_OMSORGSOVERTAKELSE(4100, "Uttak før omsorgsovertakelse"),

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/IkkeOppfyltÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/IkkeOppfyltÅrsak.java
@@ -21,6 +21,7 @@ public enum IkkeOppfyltÅrsak implements PeriodeResultatÅrsak {
     BARN_DØD(4072, "Barnet er dødt"),
     MOR_IKKE_RETT_FK(4073, "Ikke rett til kvote fordi mor ikke har rett til foreldrepenger"),
     MOR_IKKE_RETT_FP(4075, "Ikke rett til fellesperiode fordi mor ikke har rett til foreldrepenger"),
+    FAR_PERIODE_FØR_FØDSEL(4105, "Andre parten søker uttak før fødsel/omsorg"),
 
     // Adopsjon
     FØR_OMSORGSOVERTAKELSE(4100, "Uttak før omsorgsovertakelse"),

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/Manuellbehandlingårsak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/Manuellbehandlingårsak.java
@@ -18,6 +18,7 @@ public enum Manuellbehandlingårsak {
     MOR_UFØR(5027, "Mor er ufør"),
     OVERLAPPENDE_PLEIEPENGER_MED_INNLEGGELSE(5028, "Innvilget pleiepenger med innleggelse, vurder riktig ytelse"),
     OVERLAPPENDE_PLEIEPENGER_UTEN_INNLEGGELSE(5029, "Innvilget pleiepenger uten innleggelse, vurder riktig ytelse"),
+    FAR_SØKER_FØR_FØDSEL(5030, "Far/medmor periode før fødsel/omsorg"),
     ;
 
     private final int id;

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
@@ -68,7 +68,7 @@ class FedrekvoteDelregelTest {
         var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
 
         assertThat(regelresultat.oppfylt()).isFalse();
-        assertThat(regelresultat.getManuellbehandlingårsak()).isEqualTo(Manuellbehandlingårsak.SØKER_HAR_IKKE_OMSORG);
+        assertThat(regelresultat.getManuellbehandlingårsak()).isEqualTo(Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL);
     }
 
     @Test

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeOrkestreringTest.java
@@ -94,10 +94,10 @@ class FellesperiodeOrkestreringTest extends FastsettePerioderRegelOrkestreringTe
 
         assertThat(resultater).hasSize(3);
         verifiserManuellBehandlingPeriode(resultater.get(0).getUttakPeriode(), fødselsdato.minusWeeks(5),
-                fødselsdato.minusWeeks(3).minusDays(1), FELLESPERIODE, IkkeOppfyltÅrsak.FAR_HAR_IKKE_OMSORG,
-                Manuellbehandlingårsak.SØKER_HAR_IKKE_OMSORG);
+                fødselsdato.minusWeeks(3).minusDays(1), FELLESPERIODE, IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
+                Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL);
         verifiserManuellBehandlingPeriode(resultater.get(1).getUttakPeriode(), fødselsdato.minusWeeks(3), fødselsdato.minusDays(1),
-                FELLESPERIODE, IkkeOppfyltÅrsak.FAR_HAR_IKKE_OMSORG, Manuellbehandlingårsak.SØKER_HAR_IKKE_OMSORG);
+                FELLESPERIODE, IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL, Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL);
         verifiserPeriode(resultater.get(2).getUttakPeriode(), fødselsdato, fødselsdato.plusWeeks(1), Perioderesultattype.INNVILGET,
                 FELLESPERIODE);
     }

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
@@ -342,8 +342,8 @@ class ForeldrepengerDelregelTest {
 
         var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
 
-        assertManuellBehandling(regelresultat, IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER,
-                Manuellbehandlingårsak.SØKER_HAR_IKKE_OMSORG);
+        assertManuellBehandling(regelresultat, IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
+                Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL);
     }
 
     @Test

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselDelregelTest.java
@@ -101,7 +101,7 @@ class ForeldrepengerFørFødselDelregelTest {
 
         var regelresultat = kjørRegel(uttakPeriode, grunnlag);
 
-        assertManuell(regelresultat, IkkeOppfyltÅrsak.HULL_MELLOM_FORELDRENES_PERIODER, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO,
+        assertManuell(regelresultat, IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL, Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL,
                 false, false);
     }
 

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerFørFødselOrkestreringTest.java
@@ -54,7 +54,7 @@ class ForeldrepengerFørFødselOrkestreringTest extends FastsettePerioderRegelOr
         assertThat(perioder.get(0).getUttakPeriode().getPerioderesultattype()).isEqualTo(Perioderesultattype.MANUELL_BEHANDLING);
         assertThat(perioder.get(0).getUttakPeriode().getStønadskontotype()).isEqualTo(Stønadskontotype.FORELDREPENGER_FØR_FØDSEL);
         assertThat(perioder.get(0).getUttakPeriode().getManuellbehandlingårsak()).isEqualTo(
-                Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO);
+                Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL);
         assertThat(perioder.get(0).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD)).isEqualTo(Trekkdager.ZERO);
         assertThat(perioder.get(0).getUttakPeriode().getFom()).isEqualTo(fødselsdato.minusWeeks(3));
         assertThat(perioder.get(0).getUttakPeriode().getTom()).isEqualTo(fødselsdato.minusDays(1));


### PR DESCRIPTION
Dekker 4 tilfelle av far før fødsel. Har spurt Marte om vi kan avså direkte og avventer svar
Da er det bare en MSP-regel som utleder 4005 hull.
Det er 3 eksemplarer av utledningen av 4012 far/omsorg + stebarnsadopsjon.

Tenker to ting:
* Ta opp med Marte om flere "gule" tilfelle kan automatiseres og bli røde
* Se etter kandidater for å skille ut i delflyter - mistenker far før fødsel og far omsorg peker seg ut