### PR TITLE
TFP-4680 Støtte for dager uten aktivitetskrav som ikke kan utsettes

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlag.java
@@ -175,7 +175,16 @@ public interface FastsettePeriodeGrunnlag {
     boolean isBareFarHarRettMorUføretrygd();
 
     /**
-     * Har saken en minsterett for uttak
+     * Har saken perioder uten aktivitetskrav iht 14-14 tredje ledd
+     * Slike saker skal ikke ha minsterett.
+     *
+     * @return true dersom saken tilsier dager uten aktivitetskrav.
+     */
+    boolean isSakMedDagerUtenAktivitetskrav();
+
+    /**
+     * Har saken en minsterett for uttak.
+     * Slike saker skal ikke ha dager uten aktivitetskrav.
      *
      * @return true dersom saken tilsier en minsterett for uttak.
      */

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlagImpl.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlagImpl.java
@@ -180,6 +180,11 @@ public class FastsettePeriodeGrunnlagImpl implements FastsettePeriodeGrunnlag {
     }
 
     @Override
+    public boolean isSakMedDagerUtenAktivitetskrav() {
+        return regelGrunnlag.getKontoer().getUtenAktivitetskravDager() > 0;
+    }
+
+    @Override
     public List<GyldigGrunnPeriode> getGyldigGrunnPerioder() {
         return regelGrunnlag.getSøknad().getDokumentasjon().getGyldigGrunnPerioder();
     }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePerioderRegelOrkestrering.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePerioderRegelOrkestrering.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -22,7 +21,6 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeid;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeidsforhold;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriodeAktivitet;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.MorsAktivitet;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RegelGrunnlag;
@@ -307,7 +305,7 @@ public class FastsettePerioderRegelOrkestrering {
     private boolean erPeriodeMedGodkjentAktivitet(UttakPeriode periode) {
         // Inntil videre: Perioder med godkjent aktivitet iht 14-14 første ledd skal ikke gå til fratrekk på rett etter tredje ledd
         return periode.isFlerbarnsdager() || InnvilgetÅrsak.FORELDREPENGER_KUN_FAR_HAR_RETT.equals(periode.getPeriodeResultatÅrsak()) ||
-                (periode.getMorsAktivitet() != null && !Objects.equals(periode.getMorsAktivitet(), MorsAktivitet.UFØRE)); // Graderingstilfelle
+                InnvilgetÅrsak.GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT.equals(periode.getPeriodeResultatÅrsak());
     }
 
     private List<FastsattUttakPeriode> map(List<FastsettePeriodeResultat> resultatPerioder,

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
@@ -5,6 +5,7 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBa
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBareMorHarRett;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmErAleneomsorg;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmGradertPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmOmsorgHelePerioden;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmPeriodenGjelderFlerbarnsdager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmPeriodenInnenforUkerReservertMor;
@@ -14,7 +15,6 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmPe
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmSøkerErMor;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmSøknadGjelderTerminEllerFødsel;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmTilgjengeligeDagerPåNoenAktiviteteneForSøktStønadskonto;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmMinsterettMedDisponibleDager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmUttakSkjerEtterDeFørsteUkene;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmUttakStarterFørUttakForForeldrepengerFørFødsel;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorErIAktivitet;
@@ -271,15 +271,15 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmGjelderMinsterett() {
-        return rs.hvisRegel(SjekkOmMinsterettMedDisponibleDager.ID, SjekkOmMinsterettMedDisponibleDager.BESKRIVELSE)
-                .hvis(new SjekkOmMinsterettMedDisponibleDager(), sjekkGraderingVedKunFarMedmorRettMinsterett())
+        return rs.hvisRegel(SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager.ID, SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager.BESKRIVELSE)
+                .hvis(new SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager(), sjekkGraderingVedKunFarMedmorRettMinsterett())
                 .ellers(new AvslagAktivitetskravDelregel().getSpecification());
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkGraderingVedKunFarMedmorRettMinsterett() {
         return rs.hvisRegel(SjekkOmGradertPeriode.ID, SjekkOmGradertPeriode.BESKRIVELSE)
                 .hvis(new SjekkOmGradertPeriode(),
-                        Oppfylt.opprett("UT1318", InnvilgetÅrsak.GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT, true))
+                        Oppfylt.opprett("UT1318", InnvilgetÅrsak.GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, true))
                 .ellers(Oppfylt.opprett("UT1317", InnvilgetÅrsak.FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, true));
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager.java
@@ -6,18 +6,27 @@ import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
 
-@RuleDocumentation(SjekkOmMinsterettMedDisponibleDager.ID)
-public class SjekkOmMinsterettMedDisponibleDager extends LeafSpecification<FastsettePeriodeGrunnlag> {
+@RuleDocumentation(SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager.ID)
+public class SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager extends LeafSpecification<FastsettePeriodeGrunnlag> {
 
     public static final String ID = "FP_VK 10.5.4";
-    public static final String BESKRIVELSE = "Gjelder perioden dager der mor bekreftet ufør?";
+    public static final String BESKRIVELSE = "Er det disponible dager uten aktivitetskrav?";
 
-    public SjekkOmMinsterettMedDisponibleDager() {
+    public SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager() {
         super(ID);
     }
 
     @Override
     public Evaluation evaluate(FastsettePeriodeGrunnlag grunnlag) {
+        // TODO TFP-4842 - tilpass når flere tilfelle kan passere denne sjekken. Nå er den konservativ
+        if (grunnlag.isSakMedDagerUtenAktivitetskrav() && grunnlag.getAktuellPeriode().gjelderPeriodeMinsterett()) {
+            for (var aktivitet : grunnlag.getAktuellPeriode().getAktiviteter()) {
+                var saldo = grunnlag.getSaldoUtregning().restSaldoDagerUtenAktivitetskrav(grunnlag.getAktuellPeriode().getStønadskontotype(), aktivitet);
+                if (saldo.merEnn0()) {
+                    return ja();
+                }
+            }
+        }
         // TODO WLB - tilpass når flere tilfelle kan passere denne sjekken. Nå er den konservativ
         if (grunnlag.isSakMedMinsterett() && grunnlag.getAktuellPeriode().gjelderPeriodeMinsterett()) {
             for (var aktivitet : grunnlag.getAktuellPeriode().getAktiviteter()) {

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmMorBekreftetUføre.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmMorBekreftetUføre.java
@@ -9,7 +9,7 @@ import no.nav.fpsak.nare.specification.LeafSpecification;
 public class SjekkOmMorBekreftetUføre extends LeafSpecification<FastsettePeriodeGrunnlag> {
 
     public static final String ID = "AVSLAG_AKT_11";
-    public static final String BESKRIVELSE = "Har søker oppgitt at mor mottar uføretrygd ?";
+    public static final String BESKRIVELSE = "Er det bekreftet at mor mottar uføretrygd ?";
 
     public SjekkOmMorBekreftetUføre() {
         super(ID);

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/Kontoer.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/Kontoer.java
@@ -9,6 +9,7 @@ public final class Kontoer {
 
     private List<Konto> kontoList = new ArrayList<>();
     private int minsterettDager = 0;
+    private int utenAktivitetskravDager = 0;
 
     private Kontoer() {
 
@@ -20,6 +21,10 @@ public final class Kontoer {
 
     public int getMinsterettDager() {
         return minsterettDager;
+    }
+
+    public int getUtenAktivitetskravDager() {
+        return utenAktivitetskravDager;
     }
 
     public static class Builder {
@@ -41,7 +46,15 @@ public final class Kontoer {
             return this;
         }
 
+        public Builder utenAktivitetskravDager(int utenAktivitetskravDager) {
+            kladd.utenAktivitetskravDager = utenAktivitetskravDager;
+            return this;
+        }
+
         public Kontoer build() {
+            if (kladd.minsterettDager > 0 && kladd.utenAktivitetskravDager > 0) {
+                throw new IllegalArgumentException("Utviklerfeil: Sak med både minsterett og dager uten aktivitetskrav");
+            }
             return kladd;
         }
     }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/OppgittPeriode.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/OppgittPeriode.java
@@ -172,7 +172,8 @@ public final class OppgittPeriode extends LukketPeriode {
 
     public boolean gjelderPeriodeMinsterett() {
         // TODO WLB - Tilpasse til mekanismene som brukes for å søke med bakgrunn i minsterett ulike scenarier. Denne er konservativ nå.
-        return kanTrekkeAvMinsterett() && (MorsAktivitet.UFØRE.equals(morsAktivitet) || morsAktivitet == null);
+        // TODO TFP-4842 si at perioder der mors aktivitet = null
+        return kanTrekkeAvMinsterett() && MorsAktivitet.UFØRE.equals(morsAktivitet);
     }
 
     public static OppgittPeriode forManglendeSøkt(Stønadskontotype type, LocalDate fom, LocalDate tom) {

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningTjeneste.java
@@ -30,7 +30,8 @@ public final class SaldoUtregningTjeneste {
         var stønadskontoer = lagStønadskontoer(grunnlag);
         return new SaldoUtregning(stønadskontoer, søkersFastsattePerioder, annenpartsPerioder, grunnlag.isBerørtBehandling(),
                 grunnlag.getAktiviteter(), grunnlag.getSisteSøknadMottattTidspunktSøker().orElse(null),
-                grunnlag.getSisteSøknadMottattTidspunktAnnenpart().orElse(null), new Trekkdager(grunnlag.getKontoer().getMinsterettDager()));
+                grunnlag.getSisteSøknadMottattTidspunktAnnenpart().orElse(null),
+                new Trekkdager(grunnlag.getKontoer().getMinsterettDager()), new Trekkdager(grunnlag.getKontoer().getUtenAktivitetskravDager()));
     }
 
     private static List<FastsattUttakPeriode> finnRelevanteAnnenpartsPerioder(boolean isBerørtBehandling,

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/InnvilgetÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/InnvilgetÅrsak.java
@@ -14,6 +14,7 @@ public enum InnvilgetÅrsak implements PeriodeResultatÅrsak {
     GRADERING_ALENEOMSORG(2032, "Gradering ved aleneomsorg"),
     GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT(2033, "Gradering foreldrepenger, kun far har rett"),
     GRADERING_FORELDREPENGER_KUN_MOR_HAR_RETT(2034, "Gradering foreldrepenger, kun mor har rett"),
+    GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR(2035, "Gradering foreldrepenger, kun far har rett  mor er ufør"),
     FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR(2036, "Foreldrepenger, kun far har rett mor er ufør"),
 
     // Overføring årsaker

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifiserer.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifiserer.java
@@ -43,6 +43,8 @@ public class TomKontoIdentifiserer {
             }
             finnDatoMinsterettOppbrukt(uttakPeriode, aktivitet, saldoUtregning, stønadskontotype, skalTrekkeDager)
                     .ifPresent(dato -> knekkpunkter.put(dato, new TomKontoKnekkpunkt(dato)));
+            finnDatoDagerUtenAktivitetskravOppbrukt(uttakPeriode, aktivitet, saldoUtregning, stønadskontotype, skalTrekkeDager)
+                    .ifPresent(dato -> knekkpunkter.put(dato, new TomKontoKnekkpunkt(dato)));
         }
         if (knekkpunkter.isEmpty()) {
             return Optional.empty();
@@ -74,6 +76,19 @@ public class TomKontoIdentifiserer {
         }
 
         var saldoMinsterett = saldoUtregning.restSaldoMinsterett(stønadskontotype, aktivitet);
+        return datoHvisSaldoOppbruktIPeriode(oppgittPeriode, aktivitet, saldoMinsterett);
+    }
+
+    private static Optional<LocalDate> finnDatoDagerUtenAktivitetskravOppbrukt(OppgittPeriode oppgittPeriode,
+                                                                               AktivitetIdentifikator aktivitet,
+                                                                               SaldoUtregning saldoUtregning,
+                                                                               Stønadskontotype stønadskontotype,
+                                                                               boolean skalTrekkeDager) {
+        if (!oppgittPeriode.gjelderPeriodeMinsterett() || !skalTrekkeDager || Stønadskontotype.FLERBARNSDAGER.equals(stønadskontotype) ) {
+            return Optional.empty();
+        }
+
+        var saldoMinsterett = saldoUtregning.restSaldoDagerUtenAktivitetskrav(stønadskontotype, aktivitet);
         return datoHvisSaldoOppbruktIPeriode(oppgittPeriode, aktivitet, saldoMinsterett);
     }
 

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/AvslagAktivitetskravOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/AvslagAktivitetskravOrkestreringTest.java
@@ -102,6 +102,43 @@ class AvslagAktivitetskravOrkestreringTest extends FastsettePerioderRegelOrkestr
     }
 
     @Test
+    void mor_med_bekreftet_uføretrygd_skal_gå_til_manuell_dager_uten_aktivitetskrav() {
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2018, 1, 1));
+        var kontoer = new Kontoer.Builder().konto(new Konto.Builder().type(FORELDREPENGER).trekkdager(200)).utenAktivitetskravDager(20);
+        var oppgittPeriode = foreldrepenger(fødselsdato, MorsAktivitet.UFØRE);
+        var søknad = new Søknad.Builder().type(Søknadstype.FØDSEL).oppgittPeriode(oppgittPeriode);
+
+        var grunnlag = new RegelGrunnlag.Builder().behandling(farBehandling())
+                .datoer(new Datoer.Builder().fødsel(fødselsdato))
+                .rettOgOmsorg(bareFarRett().morUføretrygd(true))
+                .søknad(søknad)
+                .inngangsvilkår(oppfyltAlleVilkår())
+                .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD)))
+                .kontoer(kontoer);
+        var fastsattePerioder = fastsettPerioder(grunnlag);
+        assertThat(fastsattePerioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(InnvilgetÅrsak.FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR);
+        assertThat(fastsattePerioder.get(1).getUttakPeriode().getManuellbehandlingårsak()).isEqualTo(Manuellbehandlingårsak.MOR_UFØR);
+    }
+
+    @Test
+    void mor_med_bekreftet_ikke_uføretrygd_skal_avslås_dager_uten_aktivitetskrav() {
+        var fødselsdato = LocalDate.of(2018, 1, 1);
+        var kontoer = new Kontoer.Builder().konto(new Konto.Builder().type(FORELDREPENGER).trekkdager(200)).utenAktivitetskravDager(0);
+        var oppgittPeriode = foreldrepenger(fødselsdato, MorsAktivitet.UFØRE);
+        var søknad = new Søknad.Builder().type(Søknadstype.FØDSEL).oppgittPeriode(oppgittPeriode);
+
+        var grunnlag = new RegelGrunnlag.Builder().behandling(farBehandling())
+                .datoer(new Datoer.Builder().fødsel(fødselsdato))
+                .rettOgOmsorg(bareFarRett().morUføretrygd(false))
+                .søknad(søknad)
+                .inngangsvilkår(oppfyltAlleVilkår())
+                .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD)))
+                .kontoer(kontoer);
+        var fastsattePerioder = fastsettPerioder(grunnlag);
+        assertThat(fastsattePerioder.get(0).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_IKKE_UFØR);
+    }
+
+    @Test
     void ukjent_mors_aktivitet_skal_gå_til_manuell_hvis_ikke_dokumentert() {
         var fødselsdato = LocalDate.of(2018, 1, 1);
         var kontoer = kontoerMedFellesperiode();

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
@@ -690,7 +690,45 @@ class ForeldrepengerDelregelTest {
 
         var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
 
-        assertInnvilget(regelresultat, InnvilgetÅrsak.GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT, "UT1318");
+        assertInnvilget(regelresultat, InnvilgetÅrsak.GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, "UT1318");
+    }
+
+    @Test
+    void far_etterFamiliehendelse_utenAleneomsorg_medFarRett_utenMorRett_morUføretrygdet_ikkeFrittUttak() {
+        var familiehendelseDato = LocalDate.now().minusMonths(2);
+        var fom = familiehendelseDato.plusWeeks(8);
+        var tom = familiehendelseDato.plusWeeks(10);
+        var oppgittPeriode = OppgittPeriode.forVanligPeriode(Stønadskontotype.FORELDREPENGER, fom, tom, null, false,
+                PeriodeVurderingType.IKKE_VURDERT, familiehendelseDato, familiehendelseDato, MorsAktivitet.UFØRE);
+        var kontoer = foreldrepengerKonto(40).utenAktivitetskravDager(10);
+        var grunnlag = grunnlagFar(familiehendelseDato).søknad(søknad(oppgittPeriode))
+                .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD_1)))
+                .kontoer(kontoer)
+                .rettOgOmsorg(new RettOgOmsorg.Builder().farHarRett(true).morHarRett(false).morUføretrygd(true))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertInnvilget(regelresultat, InnvilgetÅrsak.FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, "UT1317");
+    }
+
+    @Test
+    void far_etterFamiliehendelse_utenAleneomsorg_medFarRett_utenMorRett_morUføretrygdetGradert_ikkeFrittUttak() {
+        var familiehendelseDato = LocalDate.now().minusMonths(2);
+        var fom = familiehendelseDato.plusWeeks(8);
+        var tom = familiehendelseDato.plusWeeks(10);
+        var oppgittPeriode = OppgittPeriode.forGradering(Stønadskontotype.FORELDREPENGER, fom, tom, BigDecimal.TEN, SamtidigUttaksprosent.ZERO, false,
+                Set.of(ARBEIDSFORHOLD_1), PeriodeVurderingType.IKKE_VURDERT, familiehendelseDato, familiehendelseDato, MorsAktivitet.UFØRE);
+        var kontoer = foreldrepengerKonto(40).utenAktivitetskravDager(10);
+        var grunnlag = grunnlagFar(familiehendelseDato).søknad(søknad(oppgittPeriode))
+                .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD_1)))
+                .kontoer(kontoer)
+                .rettOgOmsorg(new RettOgOmsorg.Builder().farHarRett(true).morHarRett(false).morUføretrygd(true))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertInnvilget(regelresultat, InnvilgetÅrsak.GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, "UT1318");
     }
 
     private void assertInnvilget(FastsettePerioderRegelresultat regelresultat, InnvilgetÅrsak innvilgetÅrsak) {

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/MinsterettOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/MinsterettOrkestreringTest.java
@@ -60,7 +60,7 @@ class MinsterettOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
 
     @Test
     void bfhr_mor_med_bekreftet_uføretrygd_flerbarn_skal_godkjennes() {
-        var fødselsdato = LocalDate.of(2022, 1, 1);
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 1, 1));
         var kontoer = new Kontoer.Builder().kontoList(List.of(konto(FORELDREPENGER, 285), konto(FLERBARNSDAGER, 85))).minsterettDager(75);
         var oppgittPeriode = foreldrepenger(fødselsdato, MorsAktivitet.UFØRE);
         var oppgittPeriode2 = foreldrepenger(fødselsdato.plusYears(1), MorsAktivitet.UFØRE);
@@ -82,8 +82,74 @@ class MinsterettOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
 
     @Test
     void bfhr_mor_med_bekreftet_uføretrygd_overskrider_minsterett() {
-        var fødselsdato = LocalDate.of(2022, 1, 1);
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 1, 1));
         var kontoer = new Kontoer.Builder().konto(konto(FORELDREPENGER, 200)).minsterettDager(75);
+        var oppgittPeriode = foreldrepenger(fødselsdato.plusWeeks(7), fødselsdato.plusWeeks(23).minusDays(1), MorsAktivitet.UFØRE);
+        var søknad = new Søknad.Builder().type(Søknadstype.FØDSEL).oppgittePerioder(List.of(oppgittPeriode));
+
+        var grunnlag = new RegelGrunnlag.Builder().behandling(farBehandling().kreverSammenhengendeUttak(false))
+                .datoer(new Datoer.Builder().fødsel(fødselsdato))
+                .rettOgOmsorg(bareFarRett().morUføretrygd(true))
+                .søknad(søknad)
+                .inngangsvilkår(oppfyltAlleVilkår())
+                .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD)))
+                .kontoer(kontoer);
+        var fastsattePerioder = fastsettPerioder(grunnlag);
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 75))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, BARE_FAR_RETT_IKKE_SØKT, 5))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harManuellPeriode(p.getUttakPeriode(), Manuellbehandlingårsak.MOR_UFØR, 5))).isTrue();
+    }
+
+    @Test
+    void bfhr_mor_med_bekreftet_uføretrygd_uten_aktivitetskrav_skal_godkjennes() {
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 1, 1));
+        var kontoer = new Kontoer.Builder().konto(konto(FORELDREPENGER, 200)).utenAktivitetskravDager(75);
+        var oppgittPeriode = foreldrepenger(fødselsdato, MorsAktivitet.UFØRE);
+        var oppgittPeriode2 = foreldrepenger(fødselsdato.plusWeeks(25), MorsAktivitet.UFØRE);
+        var oppgittPeriode3 = foreldrepenger(fødselsdato.plusWeeks(40), MorsAktivitet.UFØRE);
+        var søknad = new Søknad.Builder().type(Søknadstype.FØDSEL).oppgittePerioder(List.of(oppgittPeriode, oppgittPeriode2, oppgittPeriode3));
+
+        var grunnlag = new RegelGrunnlag.Builder().behandling(farBehandling().kreverSammenhengendeUttak(false))
+                .datoer(new Datoer.Builder().fødsel(fødselsdato))
+                .rettOgOmsorg(bareFarRett().morUføretrygd(true))
+                .søknad(søknad)
+                .inngangsvilkår(oppfyltAlleVilkår())
+                .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD)))
+                .kontoer(kontoer);
+        var fastsattePerioder = fastsettPerioder(grunnlag);
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 40))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 35))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harManuellPeriode(p.getUttakPeriode(), Manuellbehandlingårsak.MOR_UFØR, 5))).isTrue(); // Søkt ufør, ikke dager igjen på minstekvote
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, BARE_FAR_RETT_IKKE_SØKT, 5))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, IKKE_STØNADSDAGER_IGJEN, -1))).isTrue();
+    }
+
+    @Test
+    void bfhr_mor_med_bekreftet_uføretrygd_uten_aktivitetskrav_flerbarn_skal_godkjennes() {
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 1, 1));
+        var kontoer = new Kontoer.Builder().kontoList(List.of(konto(FORELDREPENGER, 285), konto(FLERBARNSDAGER, 85))).utenAktivitetskravDager(75);
+        var oppgittPeriode = foreldrepenger(fødselsdato, MorsAktivitet.UFØRE);
+        var oppgittPeriode2 = foreldrepenger(Virkedager.justerHelgTilMandag(fødselsdato.plusWeeks(49)), MorsAktivitet.UFØRE); // Strekker seg utover stønadsperioden
+        var søknad = new Søknad.Builder().type(Søknadstype.FØDSEL).oppgittePerioder(List.of(oppgittPeriode, oppgittPeriode2));
+
+        var grunnlag = new RegelGrunnlag.Builder().behandling(farBehandling().kreverSammenhengendeUttak(false))
+                .datoer(new Datoer.Builder().fødsel(fødselsdato))
+                .rettOgOmsorg(bareFarRett().morUføretrygd(true))
+                .søknad(søknad)
+                .inngangsvilkår(oppfyltAlleVilkår())
+                .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD)))
+                .kontoer(kontoer);
+        var fastsattePerioder = fastsettPerioder(grunnlag);
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 40))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 35))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, BARE_FAR_RETT_IKKE_SØKT, 5))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, IKKE_STØNADSDAGER_IGJEN, -1))).isTrue();
+    }
+
+    @Test
+    void bfhr_mor_med_bekreftet_uføretrygd_uten_aktivitetskrav_overskrider_minsterett() {
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 1, 1));
+        var kontoer = new Kontoer.Builder().konto(konto(FORELDREPENGER, 200)).utenAktivitetskravDager(75);
         var oppgittPeriode = foreldrepenger(fødselsdato.plusWeeks(7), fødselsdato.plusWeeks(23).minusDays(1), MorsAktivitet.UFØRE);
         var søknad = new Søknad.Builder().type(Søknadstype.FØDSEL).oppgittePerioder(List.of(oppgittPeriode));
 


### PR DESCRIPTION
Innfører dagerUtenAktivitetskrav som dekker BFHR/MU for dagens praksis - tilfelle der man ikke kan utsette uttak av disse dagene. Kun utsettelse med aktivitetskrav oppfylt er uten trekkdager.

Oppdatert tegning og innført ny graderingskode 2035 for tilfellet - enklere å skille fra flerbarn og oppfylt aktivitetskrav