### PR TITLE
TFP-4961 regler for far 2 uker FK/ForP ved fødsel og samtidig uttak av disse

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FarUttakRundtFødsel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FarUttakRundtFødsel.java
@@ -10,13 +10,13 @@ import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.LukketPeriode;
 import no.nav.foreldrepenger.regler.uttak.konfig.Konfigurasjon;
 import no.nav.foreldrepenger.regler.uttak.konfig.Parametertype;
 
-class FarUttakRundtFødsel {
+public class FarUttakRundtFødsel {
 
     private FarUttakRundtFødsel() {
         //hindrer instansiering
     }
 
-    static Optional<LukketPeriode> utledFarsPeriodeRundtFødsel(RegelGrunnlag grunnlag, Konfigurasjon konfigurasjon) {
+    public static Optional<LukketPeriode> utledFarsPeriodeRundtFødsel(RegelGrunnlag grunnlag, Konfigurasjon konfigurasjon) {
         if (grunnlag.getKontoer().getFarUttakRundtFødselDager() == 0 || !grunnlag.getSøknad().gjelderTerminFødsel()) {
             return Optional.empty();
         }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FarUttakRundtFødsel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FarUttakRundtFødsel.java
@@ -1,9 +1,7 @@
 package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
 
-import java.time.LocalDate;
 import java.time.Period;
 import java.util.Optional;
-import java.util.Set;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RegelGrunnlag;
 import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.LukketPeriode;
@@ -38,11 +36,5 @@ public class FarUttakRundtFødsel {
                 .orElse(familieHendelseDato)
                 .plus(farEtterFødsel);
         return Optional.of(new LukketPeriode(farUttakFom, farUttakTom));
-    }
-
-    static Set<LocalDate> finnKnekkpunkterFarsPeriodeRundtFødsel(RegelGrunnlag grunnlag, Konfigurasjon konfigurasjon) {
-        return utledFarsPeriodeRundtFødsel(grunnlag, konfigurasjon)
-                .map(p -> Set.of(p.getFom(), p.getTom()))
-                .orElse(Set.of());
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FarUttakRundtFødsel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FarUttakRundtFødsel.java
@@ -1,0 +1,48 @@
+package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.Optional;
+import java.util.Set;
+
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RegelGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.LukketPeriode;
+import no.nav.foreldrepenger.regler.uttak.konfig.Konfigurasjon;
+import no.nav.foreldrepenger.regler.uttak.konfig.Parametertype;
+
+class FarUttakRundtFødsel {
+
+    private FarUttakRundtFødsel() {
+        //hindrer instansiering
+    }
+
+    static Optional<LukketPeriode> utledFarsPeriodeRundtFødsel(RegelGrunnlag grunnlag, Konfigurasjon konfigurasjon) {
+        if (grunnlag.getKontoer().getFarUttakRundtFødselDager() == 0 || !grunnlag.getSøknad().gjelderTerminFødsel()) {
+            return Optional.empty();
+        }
+        // TODO: finne ut hvor strengt dette skal være i fall f < t ller f > t
+        var familieHendelseDato = grunnlag.getDatoer().getFamiliehendelse(); // Presedens: omsorg, fødsel, eller termin
+        var farFørTermin = Period.ofWeeks(konfigurasjon.getParameter(Parametertype.FAR_UTTAK_FØR_TERMIN_UKER, familieHendelseDato));
+        var farEtterFødsel =  Period.ofWeeks(konfigurasjon.getParameter(Parametertype.FAR_UTTAK_ETTER_FØDSEL_UKER, familieHendelseDato));
+        if (farFørTermin.equals(Period.ZERO) && farEtterFødsel.equals(Period.ZERO)) {
+            return Optional.empty();
+        }
+        // Bruker min(Termin-2uker, Fødsel)
+        var farUttakFom = Optional.ofNullable(grunnlag.getDatoer().getTermin())
+                .filter(d -> d.minus(farFørTermin).isBefore(familieHendelseDato))
+                .map(d -> d.minus(farFørTermin))
+                .orElse(familieHendelseDato);
+        // Bruker max(Termin, Fødsel) + 2uker - det er denne som trengs vurdering der F < T eller F < T-2u
+        var farUttakTom = Optional.ofNullable(grunnlag.getDatoer().getTermin())
+                .filter(d -> d.isAfter(familieHendelseDato))
+                .orElse(familieHendelseDato)
+                .plus(farEtterFødsel);
+        return Optional.of(new LukketPeriode(farUttakFom, farUttakTom));
+    }
+
+    static Set<LocalDate> finnKnekkpunkterFarsPeriodeRundtFødsel(RegelGrunnlag grunnlag, Konfigurasjon konfigurasjon) {
+        return utledFarsPeriodeRundtFødsel(grunnlag, konfigurasjon)
+                .map(p -> Set.of(p.getFom(), p.getTom()))
+                .orElse(Set.of());
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlag.java
@@ -10,6 +10,8 @@ import java.util.Set;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.*;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.ytelser.PleiepengerPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregning;
+import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.LukketPeriode;
+import no.nav.foreldrepenger.regler.uttak.konfig.Konfigurasjon;
 import no.nav.fpsak.nare.doc.RuleDocumentationGrunnlag;
 
 /**
@@ -247,6 +249,8 @@ public interface FastsettePeriodeGrunnlag {
     LocalDateTime getSisteSøknadMottattTidspunkt();
 
     boolean kreverBehandlingSammenhengendeUttak();
+
+    Optional<LukketPeriode> periodeFarRundtFødsel(Konfigurasjon konfigurasjon);
 
     Collection<PleiepengerPeriode> perioderMedPleiepenger();
 }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlagImpl.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlagImpl.java
@@ -15,7 +15,9 @@ import java.util.stream.Collectors;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.*;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.ytelser.PleiepengerPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregning;
+import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.LukketPeriode;
 import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.Periode;
+import no.nav.foreldrepenger.regler.uttak.konfig.Konfigurasjon;
 
 public class FastsettePeriodeGrunnlagImpl implements FastsettePeriodeGrunnlag {
 
@@ -267,6 +269,11 @@ public class FastsettePeriodeGrunnlagImpl implements FastsettePeriodeGrunnlag {
     @Override
     public boolean kreverBehandlingSammenhengendeUttak() {
         return regelGrunnlag.getBehandling().isKreverSammenhengendeUttak();
+    }
+
+    @Override
+    public Optional<LukketPeriode> periodeFarRundtFødsel(Konfigurasjon konfigurasjon) {
+        return FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(regelGrunnlag, konfigurasjon);
     }
 
     @Override

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeRegel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeRegel.java
@@ -10,8 +10,9 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBa
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBehandlingKreverSammenhengendeUttak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBerørtBehandling;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmDetErAdopsjonAvStebarn;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmEnPartsPeriodeErFlerbarnsdager;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmEnePeriodenErFarsUttakRundtFødsel;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmErGradertFørSøknadMottattdato;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmParteneMerEnn100ProsentUttak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmForeldreansvarsvilkåretErOppfylt;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmFødselsvilkåretErOppfylt;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmHvisOverlapperSåSamtykkeMellomParter;
@@ -19,6 +20,7 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmKo
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmManglendeSøktPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmOpphørsdatoTrefferPerioden;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmOpptjeningsvilkåretErOppfylt;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmParteneMerEnn100ProsentUttak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmPeriodeErFedrekvote;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmPeriodeErFellesperiode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmPeriodeErForeldrepengerFørFødsel;
@@ -165,6 +167,12 @@ public class FastsettePeriodeRegel implements RuleService<FastsettePeriodeGrunnl
     private Specification<FastsettePeriodeGrunnlag> sjekkOmFlerbarnsdager() {
         return rs.hvisRegel(SjekkOmPeriodenGjelderFlerbarnsdager.ID, "Gjelder perioden flerbarnsdager?")
                 .hvis(new SjekkOmEnPartsPeriodeErFlerbarnsdager(), sjekkOmGradertEtterSøknadMottattdato())
+                .ellers(sjekkOmFarRundtFødsel());
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmFarRundtFødsel() {
+        return rs.hvisRegel(SjekkOmEnePeriodenErFarsUttakRundtFødsel.ID, "Gjelder perioden fars uttak rundt fødsel?")
+                .hvis(new SjekkOmEnePeriodenErFarsUttakRundtFødsel(konfigurasjon), sjekkOmGradertEtterSøknadMottattdato())
                 .ellers(sjekkOmMerEnn100ProsentSamletUttak());
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePerioderRegelOrkestrering.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePerioderRegelOrkestrering.java
@@ -56,7 +56,7 @@ public class FastsettePerioderRegelOrkestrering {
         for (var aktuellPeriode : allePerioderSomSkalFastsettes) {
             FastsettePeriodeResultat resultat;
             do {
-                var saldoUtregningGrunnlag = saldoGrunnlag(grunnlag, resultatPerioder, aktuellPeriode, allePerioderSomSkalFastsettes);
+                var saldoUtregningGrunnlag = saldoGrunnlag(grunnlag, konfigurasjon, resultatPerioder, aktuellPeriode, allePerioderSomSkalFastsettes);
                 var saldoUtregning = lagUtregning(saldoUtregningGrunnlag);
                 resultat = fastsettPeriode(fastsettePeriodeRegel, konfigurasjon, grunnlag, aktuellPeriode, saldoUtregning);
                 resultatPerioder.add(resultat);
@@ -243,6 +243,7 @@ public class FastsettePerioderRegelOrkestrering {
     }
 
     private SaldoUtregningGrunnlag saldoGrunnlag(RegelGrunnlag grunnlag,
+                                                 Konfigurasjon konfigurasjon,
                                                  List<FastsettePeriodeResultat> resultatPerioder,
                                                  OppgittPeriode aktuellPeriode,
                                                  List<OppgittPeriode> allePerioderSomSkalFastsettes) {
@@ -257,12 +258,13 @@ public class FastsettePerioderRegelOrkestrering {
         if (grunnlag.getBehandling().isBerørtBehandling()) {
             var søktePerioder = new ArrayList<LukketPeriode>(allePerioderSomSkalFastsettes);
             return SaldoUtregningGrunnlag.forUtregningAvDelerAvUttakBerørtBehandling(søkersFastsattePerioder, annenpartPerioder,
-                    kontoer, utregningsdato, søktePerioder, alleAktiviteter);
+                    kontoer, utregningsdato, søktePerioder, alleAktiviteter, FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(grunnlag, konfigurasjon));
         }
         var sisteSøknadMottattTidspunktAnnenpart =
                 grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt();
         return SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(søkersFastsattePerioder, annenpartPerioder, kontoer, utregningsdato,
-                alleAktiviteter, grunnlag.getSøknad().getMottattTidspunkt(), sisteSøknadMottattTidspunktAnnenpart);
+                alleAktiviteter, grunnlag.getSøknad().getMottattTidspunkt(), sisteSøknadMottattTidspunktAnnenpart,
+                FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(grunnlag, konfigurasjon));
     }
 
     private List<FastsattUttakPeriode> vedtaksperioder(RegelGrunnlag grunnlag) {

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregel.java
@@ -175,7 +175,7 @@ public class FedrekvoteDelregel implements RuleService<FastsettePeriodeGrunnlag>
     }
 
     public Specification<FastsettePeriodeGrunnlag> sjekkOmFarsUttakRundtFødsel() {
-        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Starter perioden før uke 7 etter termin/fødsel?")
+        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Er det hjemlet fars uttak rundt fødsel?")
                 .hvis(new SjekkOmFarsUttakRundtFødselTilgjengeligeDager(konfigurasjon), delFlytForTidligUttak())
                 .ellers(uttakFørTerminFødsel());
     }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregel.java
@@ -175,7 +175,7 @@ public class FedrekvoteDelregel implements RuleService<FastsettePeriodeGrunnlag>
     }
 
     public Specification<FastsettePeriodeGrunnlag> sjekkOmFarsUttakRundtFødsel() {
-        return rs.hvisRegel(SjekkOmPeriodenStarterFørUke7.ID, "Starter perioden før uke 7 etter termin/fødsel?")
+        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Starter perioden før uke 7 etter termin/fødsel?")
                 .hvis(new SjekkOmFarsUttakRundtFødselTilgjengeligeDager(konfigurasjon), delFlytForTidligUttak())
                 .ellers(uttakFørTerminFødsel());
     }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregel.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkGyldigGrunnForTidligOppstartHelePerioden;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmFarsUttakRundtFødselTilgjengeligeDager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmGradertPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmGyldigOverføringPgaAleneomsorg;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmGyldigOverføringPgaIkkeRett;
@@ -169,8 +170,14 @@ public class FedrekvoteDelregel implements RuleService<FastsettePeriodeGrunnlag>
 
     public Specification<FastsettePeriodeGrunnlag> sjekkOmPeriodeStarterFørUke7EtterFamiliehendelse() {
         return rs.hvisRegel(SjekkOmPeriodenStarterFørUke7.ID, "Starter perioden før uke 7 etter termin/fødsel?")
-                .hvis(new SjekkOmPeriodenStarterFørUke7(konfigurasjon), uttakFørTerminFødsel())
+                .hvis(new SjekkOmPeriodenStarterFørUke7(konfigurasjon), sjekkOmFarsUttakRundtFødsel())
                 .ellers(delFlytForVanligUttak());
+    }
+
+    public Specification<FastsettePeriodeGrunnlag> sjekkOmFarsUttakRundtFødsel() {
+        return rs.hvisRegel(SjekkOmPeriodenStarterFørUke7.ID, "Starter perioden før uke 7 etter termin/fødsel?")
+                .hvis(new SjekkOmFarsUttakRundtFødselTilgjengeligeDager(konfigurasjon), delFlytForTidligUttak())
+                .ellers(uttakFørTerminFødsel());
     }
 
     public Specification<FastsettePeriodeGrunnlag> sjekkOmPeriodenGjelderFlerbarnsdager() {

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
@@ -4,6 +4,7 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkGyld
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBareFarHarRett;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBareMorHarRett;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmErAleneomsorg;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmFarsUttakRundtFødselTilgjengeligeDager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmGradertPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmMinsterettUtenAktivitetskravHarDisponibleDager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmOmsorgHelePerioden;
@@ -184,10 +185,15 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakSkalVæreFørFamileHendelse() {
         return rs.hvisRegel(SjekkOmPeriodenSlutterFørFamiliehendelse.ID, "Skal uttak være før termin/fødsel?")
-                .hvis(new SjekkOmPeriodenSlutterFørFamiliehendelse(),
-                        Manuellbehandling.opprett("UT1193", IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
-                                Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL, false, false))
+                .hvis(new SjekkOmPeriodenSlutterFørFamiliehendelse(), sjekkOmUttakFørFødselErFarRundtFødsel())
                 .ellers(sjekkErDetAleneomsorgFar());
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakFørFødselErFarRundtFødsel() {
+        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Er det hjemlet uttak rundt fødsel?")
+                .hvis(new SjekkOmFarsUttakRundtFødselTilgjengeligeDager(konfigurasjon), sjekkErDetAleneomsorgFar())
+                .ellers(Manuellbehandling.opprett("UT1193", IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
+                                Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL, false, false));
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkErDetAleneomsorgFar() {
@@ -253,6 +259,12 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakSkjerFørDeFørsteUkene() {
         return rs.hvisRegel(SjekkOmUttakSkjerEtterDeFørsteUkene.ID, SjekkOmUttakSkjerEtterDeFørsteUkene.BESKRIVELSE)
                 .hvis(new SjekkOmUttakSkjerEtterDeFørsteUkene(konfigurasjon), sjekkFarUtenAleneomsorgHarDisponibleDager())
+                .ellers(sjekkOmUttakFørsteSeksUkerErFarRundtFødsel());
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakFørsteSeksUkerErFarRundtFødsel() {
+        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Er det hjemlet uttak rundt fødsel?")
+                .hvis(new SjekkOmFarsUttakRundtFødselTilgjengeligeDager(konfigurasjon), sjekkOmAktivitetskravErOppfylt())
                 .ellers(sjekkOmGyldigGrunnForTidligOppstart());
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
@@ -190,7 +190,7 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakFørFødselErFarRundtFødsel() {
-        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Er det hjemlet uttak rundt fødsel?")
+        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Er det hjemlet fars uttak rundt fødsel?")
                 .hvis(new SjekkOmFarsUttakRundtFødselTilgjengeligeDager(konfigurasjon), sjekkErDetAleneomsorgFar())
                 .ellers(Manuellbehandling.opprett("UT1193", IkkeOppfyltÅrsak.FAR_PERIODE_FØR_FØDSEL,
                                 Manuellbehandlingårsak.FAR_SØKER_FØR_FØDSEL, false, false));
@@ -263,7 +263,7 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakFørsteSeksUkerErFarRundtFødsel() {
-        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Er det hjemlet uttak rundt fødsel?")
+        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Er det hjemlet fars uttak rundt fødsel?")
                 .hvis(new SjekkOmFarsUttakRundtFødselTilgjengeligeDager(konfigurasjon), sjekkOmAktivitetskravErOppfylt())
                 .ellers(sjekkOmGyldigGrunnForTidligOppstart());
     }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/KnekkpunktIdentifiserer.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/KnekkpunktIdentifiserer.java
@@ -67,6 +67,9 @@ class KnekkpunktIdentifiserer {
         if (grunnlag.getSøknad().getType().gjelderTerminFødsel()) {
             leggTilKnekkpunkterForTerminFødsel(knekkpunkter, familiehendelseDato, konfigurasjon);
         }
+        if (!grunnlag.getBehandling().isSøkerMor()) {
+            knekkpunkter.addAll(FarUttakRundtFødsel.finnKnekkpunkterFarsPeriodeRundtFødsel(grunnlag, konfigurasjon));
+        }
         knekkBasertPåDokumentasjon(grunnlag, knekkpunkter);
         knekkpunkter.addAll(knekkBasertPåYtelser(grunnlag));
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/KnekkpunktIdentifiserer.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/KnekkpunktIdentifiserer.java
@@ -68,7 +68,7 @@ class KnekkpunktIdentifiserer {
             leggTilKnekkpunkterForTerminFødsel(knekkpunkter, familiehendelseDato, konfigurasjon);
         }
         if (!grunnlag.getBehandling().isSøkerMor()) {
-            knekkpunkter.addAll(FarUttakRundtFødsel.finnKnekkpunkterFarsPeriodeRundtFødsel(grunnlag, konfigurasjon));
+            knekkpunkter.addAll(finnKnekkpunkterFarsPeriodeRundtFødsel(grunnlag, konfigurasjon));
         }
         knekkBasertPåDokumentasjon(grunnlag, knekkpunkter);
         knekkpunkter.addAll(knekkBasertPåYtelser(grunnlag));
@@ -229,6 +229,12 @@ class KnekkpunktIdentifiserer {
                 konfigurasjon.getParameter(Parametertype.UTTAK_FELLESPERIODE_FØR_FØDSEL_UKER, familiehendelseDato)));
         knekkpunkter.add(familiehendelseDato.plusWeeks(
                 konfigurasjon.getParameter(Parametertype.UTTAK_MØDREKVOTE_ETTER_FØDSEL_UKER, familiehendelseDato)));
+    }
+
+    private static Set<LocalDate> finnKnekkpunkterFarsPeriodeRundtFødsel(RegelGrunnlag grunnlag, Konfigurasjon konfigurasjon) {
+        return FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(grunnlag, konfigurasjon)
+                .map(p -> Set.of(p.getFom(), p.getTom()))
+                .orElse(Set.of());
     }
 
     private static void leggTilKnekkpunkter(Set<LocalDate> knekkpunkter, List<? extends Periode> perioder) {

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmEnPartsPeriodeErFlerbarnsdager.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmEnPartsPeriodeErFlerbarnsdager.java
@@ -1,5 +1,6 @@
-package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
+package no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser;
 
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunnlag;
 import no.nav.foreldrepenger.regler.uttak.felles.PerioderUtenHelgUtil;
 import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmEnePeriodenErFarsUttakRundtFødsel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmEnePeriodenErFarsUttakRundtFødsel.java
@@ -1,0 +1,43 @@
+package no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser;
+
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.felles.PerioderUtenHelgUtil;
+import no.nav.foreldrepenger.regler.uttak.konfig.Konfigurasjon;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+
+@RuleDocumentation(SjekkOmEnePeriodenErFarsUttakRundtFødsel.ID)
+public class SjekkOmEnePeriodenErFarsUttakRundtFødsel extends LeafSpecification<FastsettePeriodeGrunnlag> {
+
+    public static final String ID = "FP_VK 30.0.10";
+
+    private Konfigurasjon konfigurasjon;
+
+    public SjekkOmEnePeriodenErFarsUttakRundtFødsel(Konfigurasjon konfigurasjon) {
+        super(ID);
+        this.konfigurasjon = konfigurasjon;
+    }
+
+    @Override
+    public Evaluation evaluate(FastsettePeriodeGrunnlag grunnlag) {
+        var aktuellPeriode = grunnlag.getAktuellPeriode();
+        var farRundtFødselPeriode = grunnlag.periodeFarRundtFødsel(konfigurasjon);
+        // Far og periode innenfor intervall rundt fødsel
+        if (!grunnlag.isSøkerMor() && farRundtFødselPeriode.filter(aktuellPeriode::erOmsluttetAv).isPresent()) {
+            return ja();
+        }
+
+        // Mor og annanpart har periode innenfor intervall rundt fødsel
+        if (grunnlag.isSøkerMor() && farRundtFødselPeriode.isPresent()) {
+            for (var periodeAnnenPart : grunnlag.getAnnenPartUttaksperioder()) {
+                if (PerioderUtenHelgUtil.perioderUtenHelgOverlapper(aktuellPeriode, periodeAnnenPart)
+                        && periodeAnnenPart.erOmsluttetAv(farRundtFødselPeriode.get())) {
+                    return ja();
+                }
+            }
+        }
+        return nei();
+
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmFarsUttakRundtFødselTilgjengeligeDager.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmFarsUttakRundtFødselTilgjengeligeDager.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.Trekkdager;
 import no.nav.foreldrepenger.regler.uttak.konfig.Konfigurasjon;
 import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;
@@ -20,7 +21,7 @@ public class SjekkOmFarsUttakRundtFødselTilgjengeligeDager extends LeafSpecific
 
     @Override
     public Evaluation evaluate(FastsettePeriodeGrunnlag grunnlag) {
-        if (grunnlag.isSøkerMor() || grunnlag.periodeFarRundtFødsel(konfigurasjon).isEmpty()) {
+        if (grunnlag.isSøkerMor() || grunnlag.getSaldoUtregning().getFarUttakRundtFødselDager().equals(Trekkdager.ZERO) || grunnlag.periodeFarRundtFødsel(konfigurasjon).isEmpty()) {
             return nei();
         }
         var periodeForUttakRundtFødsel = grunnlag.periodeFarRundtFødsel(konfigurasjon).orElseThrow();

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmFarsUttakRundtFødselTilgjengeligeDager.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmFarsUttakRundtFødselTilgjengeligeDager.java
@@ -1,0 +1,38 @@
+package no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser;
+
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.konfig.Konfigurasjon;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+
+@RuleDocumentation(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID)
+public class SjekkOmFarsUttakRundtFødselTilgjengeligeDager extends LeafSpecification<FastsettePeriodeGrunnlag> {
+
+    public static final String ID = "FP_VK 13.9";
+
+    private Konfigurasjon konfigurasjon;
+
+    public SjekkOmFarsUttakRundtFødselTilgjengeligeDager(Konfigurasjon konfigurasjon) {
+        super(ID);
+        this.konfigurasjon = konfigurasjon;
+    }
+
+    @Override
+    public Evaluation evaluate(FastsettePeriodeGrunnlag grunnlag) {
+        if (grunnlag.isSøkerMor() || grunnlag.periodeFarRundtFødsel(konfigurasjon).isEmpty()) {
+            return nei();
+        }
+        var periodeForUttakRundtFødsel = grunnlag.periodeFarRundtFødsel(konfigurasjon).orElseThrow();
+        var aktuellPeriode = grunnlag.getAktuellPeriode();
+        if (aktuellPeriode.erOmsluttetAv(periodeForUttakRundtFødsel)) {
+            for (var aktivitet : aktuellPeriode.getAktiviteter()) {
+                var saldo = grunnlag.getSaldoUtregning().restSaldoFarUttakRundtFødsel(aktivitet);
+                if (saldo.merEnn0()) {
+                    return ja();
+                }
+            }
+        }
+        return nei();
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmPeriodenErEtterMaksgrenseForUttak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmPeriodenErEtterMaksgrenseForUttak.java
@@ -33,8 +33,7 @@ public class SjekkOmPeriodenErEtterMaksgrenseForUttak extends LeafSpecification<
     }
 
     public static LocalDate regnUtMaksgrenseForLovligeUttaksdag(LocalDate familiehendelse, Konfigurasjon konfigurasjon) {
-        var maksGrenseRelativTilFamiliehendelse = konfigurasjon.getParameter(Parametertype.GRENSE_ETTER_FØDSELSDATO, Period.class,
-                familiehendelse);
+        var maksGrenseRelativTilFamiliehendelse = Period.ofYears(konfigurasjon.getParameter(Parametertype.GRENSE_ETTER_FØDSELSDATO_ÅR, familiehendelse));
         return familiehendelse.plus(maksGrenseRelativTilFamiliehendelse);
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/Kontoer.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/Kontoer.java
@@ -11,6 +11,7 @@ public final class Kontoer {
     private int minsterettDager = 0;
     private int utenAktivitetskravDager = 0;
     private int flerbarnsdager = 0;
+    private int farUttakRundtFødselDager = 0;
 
     private Kontoer() {
 
@@ -32,6 +33,10 @@ public final class Kontoer {
         return flerbarnsdager;
     }
 
+    public int getFarUttakRundtFødselDager() {
+        return farUttakRundtFødselDager;
+    }
+
     public static class Builder {
 
         private final Kontoer kladd = new Kontoer();
@@ -43,6 +48,11 @@ public final class Kontoer {
 
         public Builder kontoList(List<Konto.Builder> kontoList) {
             kladd.kontoList = kontoList.stream().map(Konto.Builder::build).collect(Collectors.toList());
+            return this;
+        }
+
+        public Builder farUttakRundtFødselDager(int farUttakRundtFødselDager) {
+            kladd.farUttakRundtFødselDager = farUttakRundtFødselDager;
             return this;
         }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningGrunnlag.java
@@ -23,6 +23,7 @@ public class SaldoUtregningGrunnlag {
     private final Set<AktivitetIdentifikator> aktiviteter;
     private final LocalDateTime sisteSøknadMottattTidspunktSøker;
     private final LocalDateTime sisteSøknadMottattTidspunktAnnenpart;
+    private final Optional<LukketPeriode> farUttakRundtFødselPeriode;
 
     private SaldoUtregningGrunnlag(List<FastsattUttakPeriode> søkersFastsattePerioder,
                                    LocalDate utregningsdato,
@@ -32,18 +33,21 @@ public class SaldoUtregningGrunnlag {
                                    Kontoer kontoer,
                                    Set<AktivitetIdentifikator> aktiviteter,
                                    LocalDateTime sisteSøknadMottattTidspunktSøker,
-                                   LocalDateTime sisteSøknadMottattTidspunktAnnenpart) {
+                                   LocalDateTime sisteSøknadMottattTidspunktAnnenpart,
+                                   Optional<LukketPeriode> farUttakRundtFødselPeriode) {
         this.søkersFastsattePerioder = søkersFastsattePerioder;
         this.utregningsdato = utregningsdato;
         this.berørtBehandling = berørtBehandling;
         this.annenpartsPerioder = annenpartsPerioder;
         this.søktePerioder = søktePerioder;
         this.kontoer = kontoer;
+        this.farUttakRundtFødselPeriode = farUttakRundtFødselPeriode;
         this.aktiviteter = aktiviteter;
         this.sisteSøknadMottattTidspunktSøker = sisteSøknadMottattTidspunktSøker;
         this.sisteSøknadMottattTidspunktAnnenpart = sisteSøknadMottattTidspunktAnnenpart;
     }
 
+    @Deprecated(forRemoval = true)
     public static SaldoUtregningGrunnlag forUtregningAvHeleUttaket(List<FastsattUttakPeriode> søkersFastsattePerioder,
                                                                    boolean berørtBehandling,
                                                                    List<AnnenpartUttakPeriode> annenpartsPerioder,
@@ -55,7 +59,22 @@ public class SaldoUtregningGrunnlag {
                 .map(a -> a.getAktivitetIdentifikator())
                 .collect(Collectors.toSet());
         return new SaldoUtregningGrunnlag(søkersFastsattePerioder, LocalDate.MAX, berørtBehandling, annenpartsPerioder, List.of(),
-                kontoer, aktiviteter, sisteSøknadMottattTidspunktSøker, sisteSøknadMottattTidspunktAnnenpart);
+                kontoer, aktiviteter, sisteSøknadMottattTidspunktSøker, sisteSøknadMottattTidspunktAnnenpart, Optional.empty());
+    }
+
+    public static SaldoUtregningGrunnlag forUtregningAvHeleUttaket(List<FastsattUttakPeriode> søkersFastsattePerioder,
+                                                                   boolean berørtBehandling,
+                                                                   List<AnnenpartUttakPeriode> annenpartsPerioder,
+                                                                   Kontoer kontoer,
+                                                                   LocalDateTime sisteSøknadMottattTidspunktSøker,
+                                                                   LocalDateTime sisteSøknadMottattTidspunktAnnenpart,
+                                                                   Optional<LukketPeriode> farUttakRundtFødselPeriode) {
+        var aktiviteter = søkersFastsattePerioder.stream()
+                .flatMap(p -> p.getAktiviteter().stream())
+                .map(a -> a.getAktivitetIdentifikator())
+                .collect(Collectors.toSet());
+        return new SaldoUtregningGrunnlag(søkersFastsattePerioder, LocalDate.MAX, berørtBehandling, annenpartsPerioder, List.of(),
+                kontoer, aktiviteter, sisteSøknadMottattTidspunktSøker, sisteSøknadMottattTidspunktAnnenpart, farUttakRundtFødselPeriode);
     }
 
     public static SaldoUtregningGrunnlag forUtregningAvDelerAvUttak(List<FastsattUttakPeriode> søkersFastsattePerioder,
@@ -64,9 +83,10 @@ public class SaldoUtregningGrunnlag {
                                                                     LocalDate utregningsdato,
                                                                     Set<AktivitetIdentifikator> aktiviteter,
                                                                     LocalDateTime sisteSøknadMottattTidspunktSøker,
-                                                                    LocalDateTime sisteSøknadMottattTidspunktAnnenpart) {
+                                                                    LocalDateTime sisteSøknadMottattTidspunktAnnenpart,
+                                                                    Optional<LukketPeriode> farUttakRundtFødselPeriode) {
         return new SaldoUtregningGrunnlag(søkersFastsattePerioder, utregningsdato, false, annenpartsPerioder, List.of(), kontoer,
-                aktiviteter, sisteSøknadMottattTidspunktSøker, sisteSøknadMottattTidspunktAnnenpart);
+                aktiviteter, sisteSøknadMottattTidspunktSøker, sisteSøknadMottattTidspunktAnnenpart, farUttakRundtFødselPeriode);
     }
 
     public static SaldoUtregningGrunnlag forUtregningAvDelerAvUttakBerørtBehandling(List<FastsattUttakPeriode> søkersFastsattePerioder,
@@ -74,9 +94,10 @@ public class SaldoUtregningGrunnlag {
                                                                                     Kontoer kontoer,
                                                                                     LocalDate utregningsdato,
                                                                                     List<LukketPeriode> søktePerioder,
-                                                                                    Set<AktivitetIdentifikator> aktiviteter) {
+                                                                                    Set<AktivitetIdentifikator> aktiviteter,
+                                                                                    Optional<LukketPeriode> farUttakRundtFødselPeriode) {
         return new SaldoUtregningGrunnlag(søkersFastsattePerioder, utregningsdato, true, annenpartsPerioder, søktePerioder, kontoer,
-                aktiviteter, null, null);
+                aktiviteter, null, null, farUttakRundtFødselPeriode);
     }
 
     List<FastsattUttakPeriode> getSøkersFastsattePerioder() {
@@ -101,6 +122,10 @@ public class SaldoUtregningGrunnlag {
 
     public Kontoer getKontoer() {
         return kontoer;
+    }
+
+    public Optional<LukketPeriode> getFarUttakRundtFødselPeriode() {
+        return farUttakRundtFødselPeriode;
     }
 
     public Set<AktivitetIdentifikator> getAktiviteter() {

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningTjeneste.java
@@ -35,7 +35,9 @@ public final class SaldoUtregningTjeneste {
                 grunnlag.getSisteSøknadMottattTidspunktAnnenpart().orElse(null),
                 new Trekkdager(grunnlag.getKontoer().getMinsterettDager()),
                 new Trekkdager(grunnlag.getKontoer().getUtenAktivitetskravDager()),
-                new Trekkdager(grunnlag.getKontoer().getFlerbarnsdager()));
+                new Trekkdager(grunnlag.getKontoer().getFlerbarnsdager()),
+                grunnlag.getFarUttakRundtFødselPeriode(),
+                new Trekkdager(grunnlag.getKontoer().getFarUttakRundtFødselDager()));
     }
 
     private static List<FastsattUttakPeriode> knekkSøkersOppholdsperioder(List<FastsattUttakPeriode> annenpartsPerioder,

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifiserer.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifiserer.java
@@ -15,9 +15,9 @@ import java.util.Set;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.Trekkdager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktivitetIdentifikator;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregning;
 import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 
 public class TomKontoIdentifiserer {
 
@@ -44,6 +44,8 @@ public class TomKontoIdentifiserer {
             finnDatoMinsterettOppbrukt(uttakPeriode, aktivitet, saldoUtregning, skalTrekkeDager)
                     .ifPresent(dato -> knekkpunkter.put(dato, new TomKontoKnekkpunkt(dato)));
             finnDatoDagerUtenAktivitetskravOppbrukt(uttakPeriode, aktivitet, saldoUtregning, skalTrekkeDager)
+                    .ifPresent(dato -> knekkpunkter.put(dato, new TomKontoKnekkpunkt(dato)));
+            finnDatoFarRundtFødselOppbrukt(uttakPeriode, aktivitet, saldoUtregning, skalTrekkeDager)
                     .ifPresent(dato -> knekkpunkter.put(dato, new TomKontoKnekkpunkt(dato)));
         }
         if (knekkpunkter.isEmpty()) {
@@ -99,6 +101,16 @@ public class TomKontoIdentifiserer {
 
         var saldoMinsterett = saldoUtregning.restSaldoDagerUtenAktivitetskrav(aktivitet);
         return datoHvisSaldoOppbruktIPeriode(oppgittPeriode, aktivitet, saldoMinsterett);
+    }
+
+    private static Optional<LocalDate> finnDatoFarRundtFødselOppbrukt(OppgittPeriode oppgittPeriode,
+                                                                      AktivitetIdentifikator aktivitet,
+                                                                      SaldoUtregning saldoUtregning, boolean skalTrekkeDager) {
+        if (saldoUtregning.getFarUttakRundtFødselDager().equals(Trekkdager.ZERO) || !skalTrekkeDager || !saldoUtregning.erPeriodeRelevantForFarUttakRundtFødselDager(oppgittPeriode)) {
+            return Optional.empty();
+        }
+        var saldoFarRundtFødsel = saldoUtregning.restSaldoFarUttakRundtFødsel(aktivitet);
+        return datoHvisSaldoOppbruktIPeriode(oppgittPeriode, aktivitet, saldoFarRundtFødsel);
     }
 
     private static Optional<LocalDate> datoHvisSaldoOppbruktIPeriode(OppgittPeriode oppgittPeriode,

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/konfig/Parametertype.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/konfig/Parametertype.java
@@ -30,7 +30,11 @@ public enum Parametertype {
     UTTAK_FELLESPERIODE_FØR_FØDSEL_UKER,
     UTTAK_ETTER_BARN_DØDT_UKER,
     PREMATURUKER_ANTALL_DAGER_FØR_TERMIN,
+    FAR_UTTAK_FØR_TERMIN_UKER,
+    FAR_UTTAK_ETTER_FØDSEL_UKER,
 
+    GRENSE_ETTER_FØDSELSDATO_ÅR,
+    @Deprecated(forRemoval = true)
     GRENSE_ETTER_FØDSELSDATO(Period.class);
 
     private final Class<?> klasseForVerdier;

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/konfig/StandardKonfigurasjon.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/konfig/StandardKonfigurasjon.java
@@ -13,6 +13,8 @@ public class StandardKonfigurasjon {
 
     static {
         var d_2017_01_01 = LocalDate.of(2017, Month.JANUARY, 1);
+        var d_2019_07_01 = LocalDate.of(2019, Month.JULY, 1);
+        var d_2022_08_02 = LocalDate.of(2022, Month.AUGUST, 1);
         KONFIGURASJON = KonfigurasjonBuilder.create()
                 //Stønadskontoer
                 .leggTilParameter(Parametertype.EKSTRA_DAGER_TO_BARN_FOR_DEKNINGSGRAD_100, d_2017_01_01, null, 85)
@@ -37,64 +39,56 @@ public class StandardKonfigurasjon {
                 .leggTilParameter(Parametertype.LOVLIG_UTTAK_FØR_FØDSEL_UKER, d_2017_01_01, null, 12)
                 .leggTilParameter(Parametertype.UTTAK_FELLESPERIODE_FØR_FØDSEL_UKER, d_2017_01_01, null, 3)
                 .leggTilParameter(Parametertype.UTTAK_ETTER_BARN_DØDT_UKER, d_2017_01_01, null, 6)
+                .leggTilParameter(Parametertype.FAR_UTTAK_FØR_TERMIN_UKER, d_2017_01_01, null, 2) // TODO: endre til aug 2022 etter overgang
+                .leggTilParameter(Parametertype.FAR_UTTAK_ETTER_FØDSEL_UKER, d_2017_01_01, null, 2) // TODO: endre til aug 2022 etter overgang
                 //grenser
                 .leggTilParameter(Parametertype.GRENSE_ETTER_FØDSELSDATO, d_2017_01_01, null, Period.ofYears(3))
-                .leggTilParameter(Parametertype.PREMATURUKER_ANTALL_DAGER_FØR_TERMIN, LocalDate.of(2019, 7, 1), null, 52)
+                .leggTilParameter(Parametertype.GRENSE_ETTER_FØDSELSDATO_ÅR, d_2017_01_01, null, 3)
+                .leggTilParameter(Parametertype.PREMATURUKER_ANTALL_DAGER_FØR_TERMIN, d_2019_07_01, null, 52)
                 .build();
         var d_2010_01_01 = LocalDate.of(2010, Month.JANUARY, 1);
         var d_2018_12_31 = LocalDate.of(2018, Month.DECEMBER, 31);
         var d_2019_01_01 = LocalDate.of(2019, Month.JANUARY, 1);
         SØKNADSDIALOG = KonfigurasjonBuilder.create()
-                //Stønadskontoer
-                .leggTilParameter(Parametertype.EKSTRA_DAGER_TO_BARN_FOR_DEKNINGSGRAD_100, d_2019_01_01, null, 85)
-                .leggTilParameter(Parametertype.EKSTRA_DAGER_TO_BARN_FOR_DEKNINGSGRAD_80, d_2019_01_01, null, 105)
-                .leggTilParameter(Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN_FOR_DEKNINGSGRAD_100, d_2019_01_01, null, 230)
-                .leggTilParameter(Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN_FOR_DEKNINGSGRAD_80, d_2019_01_01, null, 280)
-                .leggTilParameter(Parametertype.MØDREKVOTE_DAGER_100_PROSENT, d_2019_01_01, null, 75)
-                .leggTilParameter(Parametertype.FEDREKVOTE_DAGER_100_PROSENT, d_2019_01_01, null, 75)
+                /*
+                 * Stønadskontoer
+                 * - endring av kvoter/80% fom 1/1-2019
+                 * - prematuruker 1/7-2019
+                 */
+                .leggTilParameter(Parametertype.EKSTRA_DAGER_TO_BARN_FOR_DEKNINGSGRAD_100, d_2010_01_01, null, 85)
+                .leggTilParameter(Parametertype.EKSTRA_DAGER_TO_BARN_FOR_DEKNINGSGRAD_80, d_2010_01_01, null, 105)
+                .leggTilParameter(Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN_FOR_DEKNINGSGRAD_100, d_2010_01_01, null, 230)
+                .leggTilParameter(Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN_FOR_DEKNINGSGRAD_80, d_2010_01_01, null, 280)
+                .leggTilParameter(Parametertype.MØDREKVOTE_DAGER_100_PROSENT, d_2010_01_01, null, 75)
+                .leggTilParameter(Parametertype.FEDREKVOTE_DAGER_100_PROSENT, d_2010_01_01, null, 75)
                 .leggTilParameter(Parametertype.MØDREKVOTE_DAGER_80_PROSENT, d_2019_01_01, null, 95)
                 .leggTilParameter(Parametertype.FEDREKVOTE_DAGER_80_PROSENT, d_2019_01_01, null, 95)
-                .leggTilParameter(Parametertype.FELLESPERIODE_100_PROSENT_BEGGE_RETT_DAGER, d_2019_01_01, null, 80)
-                .leggTilParameter(Parametertype.FELLESPERIODE_80_PROSENT_BEGGE_RETT_DAGER, d_2019_01_01, null, 90)
-                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_MOR_ALENEOMSORG_DAGER, d_2019_01_01, null, 230)
-                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_MOR_ALENEOMSORG_DAGER, d_2019_01_01, null, 280)
-                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_FAR_ALENEOMSORG_DAGER, d_2019_01_01, null, 230)
-                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_FAR_ALENEOMSORG_DAGER, d_2019_01_01, null, 280)
-                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_FAR_HAR_RETT_DAGER, d_2019_01_01, null, 200)
-                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_HAR_RETT_DAGER, d_2019_01_01, null, 250)
-                .leggTilParameter(Parametertype.FORELDREPENGER_FØR_FØDSEL, d_2019_01_01, null, 15)
-
-                .leggTilParameter(Parametertype.EKSTRA_DAGER_TO_BARN_FOR_DEKNINGSGRAD_100, d_2010_01_01, d_2018_12_31, 85)
-                .leggTilParameter(Parametertype.EKSTRA_DAGER_TO_BARN_FOR_DEKNINGSGRAD_80, d_2010_01_01, d_2018_12_31, 105)
-                .leggTilParameter(Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN_FOR_DEKNINGSGRAD_100, d_2010_01_01, d_2018_12_31,
-                        230)
-                .leggTilParameter(Parametertype.EKSTRA_DAGER_TRE_ELLER_FLERE_BARN_FOR_DEKNINGSGRAD_80, d_2010_01_01, d_2018_12_31, 280)
-                .leggTilParameter(Parametertype.MØDREKVOTE_DAGER_100_PROSENT, d_2010_01_01, d_2018_12_31, 75)
-                .leggTilParameter(Parametertype.FEDREKVOTE_DAGER_100_PROSENT, d_2010_01_01, d_2018_12_31, 75)
                 .leggTilParameter(Parametertype.MØDREKVOTE_DAGER_80_PROSENT, d_2010_01_01, d_2018_12_31, 75)
                 .leggTilParameter(Parametertype.FEDREKVOTE_DAGER_80_PROSENT, d_2010_01_01, d_2018_12_31, 75)
-                .leggTilParameter(Parametertype.FELLESPERIODE_100_PROSENT_BEGGE_RETT_DAGER, d_2010_01_01, d_2018_12_31, 80)
-                .leggTilParameter(Parametertype.FELLESPERIODE_80_PROSENT_BEGGE_RETT_DAGER, d_2010_01_01, d_2018_12_31, 130)
-                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_MOR_ALENEOMSORG_DAGER, d_2010_01_01, d_2018_12_31, 230)
-                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_MOR_ALENEOMSORG_DAGER, d_2010_01_01, d_2018_12_31, 280)
-                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_FAR_ALENEOMSORG_DAGER, d_2010_01_01, d_2018_12_31, 230)
-                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_FAR_ALENEOMSORG_DAGER, d_2010_01_01, d_2018_12_31, 280)
-                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_FAR_HAR_RETT_DAGER, d_2010_01_01, d_2018_12_31, 200)
-                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_HAR_RETT_DAGER, d_2010_01_01, d_2018_12_31, 250)
-                .leggTilParameter(Parametertype.FORELDREPENGER_FØR_FØDSEL, d_2010_01_01, d_2018_12_31, 15)
-                //Uttaksperioder
-                .leggTilParameter(Parametertype.UTTAK_MØDREKVOTE_ETTER_FØDSEL_UKER, d_2019_01_01, null, 6)
-                .leggTilParameter(Parametertype.LOVLIG_UTTAK_FØR_FØDSEL_UKER, d_2019_01_01, null, 12)
-                .leggTilParameter(Parametertype.UTTAK_FELLESPERIODE_FØR_FØDSEL_UKER, d_2019_01_01, null, 3)
 
-                .leggTilParameter(Parametertype.UTTAK_MØDREKVOTE_ETTER_FØDSEL_UKER, d_2010_01_01, d_2018_12_31, 6)
-                .leggTilParameter(Parametertype.LOVLIG_UTTAK_FØR_FØDSEL_UKER, d_2010_01_01, d_2018_12_31, 12)
-                .leggTilParameter(Parametertype.UTTAK_FELLESPERIODE_FØR_FØDSEL_UKER, d_2010_01_01, d_2018_12_31, 3)
+                .leggTilParameter(Parametertype.FELLESPERIODE_100_PROSENT_BEGGE_RETT_DAGER, d_2010_01_01, null, 80)
+                .leggTilParameter(Parametertype.FELLESPERIODE_80_PROSENT_BEGGE_RETT_DAGER, d_2019_01_01, null, 90)
+                .leggTilParameter(Parametertype.FELLESPERIODE_80_PROSENT_BEGGE_RETT_DAGER, d_2010_01_01, d_2018_12_31, 130)
+                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_MOR_ALENEOMSORG_DAGER, d_2010_01_01, null, 230)
+                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_MOR_ALENEOMSORG_DAGER, d_2010_01_01, null, 280)
+                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_FAR_ALENEOMSORG_DAGER, d_2010_01_01, null, 230)
+                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_FAR_ALENEOMSORG_DAGER, d_2010_01_01, null, 280)
+                .leggTilParameter(Parametertype.FORELDREPENGER_100_PROSENT_FAR_HAR_RETT_DAGER, d_2010_01_01, null, 200)
+                .leggTilParameter(Parametertype.FORELDREPENGER_80_PROSENT_HAR_RETT_DAGER, d_2010_01_01, null, 250)
+                .leggTilParameter(Parametertype.FORELDREPENGER_FØR_FØDSEL, d_2010_01_01, null, 15)
+
+                //Uttaksperioder
+                .leggTilParameter(Parametertype.UTTAK_MØDREKVOTE_ETTER_FØDSEL_UKER, d_2010_01_01, null, 6)
+                .leggTilParameter(Parametertype.LOVLIG_UTTAK_FØR_FØDSEL_UKER, d_2010_01_01, null, 12)
+                .leggTilParameter(Parametertype.UTTAK_FELLESPERIODE_FØR_FØDSEL_UKER, d_2010_01_01, null, 3)
+
                 .leggTilParameter(Parametertype.UTTAK_ETTER_BARN_DØDT_UKER, d_2017_01_01, null, 6)
+                .leggTilParameter(Parametertype.FAR_UTTAK_FØR_TERMIN_UKER, d_2022_08_02, null, 2)
+                .leggTilParameter(Parametertype.FAR_UTTAK_ETTER_FØDSEL_UKER, d_2022_08_02, null, 2)
                 //grenser
-                .leggTilParameter(Parametertype.GRENSE_ETTER_FØDSELSDATO, d_2019_01_01, null, Period.ofYears(3))
-                .leggTilParameter(Parametertype.GRENSE_ETTER_FØDSELSDATO, d_2010_01_01, d_2018_12_31, Period.ofYears(3))
-                .leggTilParameter(Parametertype.PREMATURUKER_ANTALL_DAGER_FØR_TERMIN, LocalDate.of(2019, 7, 1), null, 52)
+                .leggTilParameter(Parametertype.GRENSE_ETTER_FØDSELSDATO, d_2010_01_01, null, Period.ofYears(3))
+                .leggTilParameter(Parametertype.GRENSE_ETTER_FØDSELSDATO_ÅR, d_2010_01_01, null, 3)
+                .leggTilParameter(Parametertype.PREMATURUKER_ANTALL_DAGER_FØR_TERMIN, d_2019_07_01, null, 52)
                 .build();
     }
 

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/DelRegelTestUtil.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/DelRegelTestUtil.java
@@ -28,7 +28,8 @@ final class DelRegelTestUtil {
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(søkersFastsattePerioder, List.of(),
                 grunnlag.getKontoer(), oppgittPeriode.getFom(), grunnlag.getArbeid().getAktiviteter(),
                 grunnlag.getSøknad().getMottattTidspunkt(),
-                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt());
+                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt(),
+                FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(grunnlag, StandardKonfigurasjon.KONFIGURASJON));
         oppgittPeriode.setAktiviteter(grunnlag.getArbeid().getAktiviteter());
         return new FastsettePerioderRegelresultat(REGEL.evaluer(
                 new FastsettePeriodeGrunnlagImpl(grunnlag, SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag),

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
@@ -17,6 +17,8 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅr
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.InnvilgetÅrsak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.Manuellbehandlingårsak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.UtfallType;
+import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
+import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.LukketPeriode;
 
 class FedrekvoteDelregelTest {
 
@@ -377,6 +379,13 @@ class FedrekvoteDelregelTest {
         var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
 
         assertThat(regelresultat.oppfylt()).isFalse();
+    }
+
+    @Test
+    void dummy() {
+        var fødselsdato = LocalDate.of(2022, 9, 30);
+        var intervall = new LukketPeriode(fødselsdato, fødselsdato.plusWeeks(2));
+        System.out.println(Virkedager.beregnAntallVirkedager(intervall));
     }
 
     @Test

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
@@ -382,13 +382,6 @@ class FedrekvoteDelregelTest {
     }
 
     @Test
-    void dummy() {
-        var fødselsdato = LocalDate.of(2022, 9, 30);
-        var intervall = new LukketPeriode(fødselsdato, fødselsdato.plusWeeks(2));
-        System.out.println(Virkedager.beregnAntallVirkedager(intervall));
-    }
-
-    @Test
     void fedrekvote_rundt_fødsel_uten_termin_periode_før_fødsel_blir_avslått() {
         var fødselsdato = LocalDate.of(2022, 10, 1);
 

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
@@ -345,6 +345,55 @@ class FedrekvoteDelregelTest {
         assertThat(regelresultat.getManuellbehandlingårsak()).isEqualTo(Manuellbehandlingårsak.OPPHOLD_STØRRE_ENN_TILGJENGELIGE_DAGER);
     }
 
+    @Test
+    void fedrekvote_rundt_fødsel_blir_innvilget() {
+        var fødselsdato = LocalDate.of(2022, 10, 1);
+
+        var oppgittPeriode = oppgittPeriode(fødselsdato, fødselsdato.plusWeeks(1).plusDays(1));
+        var grunnlag = basicGrunnlag(fødselsdato)
+                .behandling(new Behandling.Builder().søkerErMor(false))
+                .søknad(søknad(oppgittPeriode))
+                .kontoer(fedrekvoteKonto(10 * 5).farUttakRundtFødselDager(10))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertThat(regelresultat.oppfylt()).isTrue();
+    }
+
+    @Test
+    void fedrekvote_rundt_fødsel__men_før_fødsel_blir_avslått() {
+        var fødselsdato = LocalDate.of(2022, 10, 1);
+
+        var oppgittPeriode = oppgittPeriode(fødselsdato.minusDays(2), fødselsdato.plusWeeks(1).plusDays(1));
+        var grunnlag = basicGrunnlag(fødselsdato)
+                .behandling(new Behandling.Builder().søkerErMor(false))
+                .søknad(søknad(oppgittPeriode))
+                .kontoer(fedrekvoteKonto(10 * 5).farUttakRundtFødselDager(10))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertThat(regelresultat.oppfylt()).isFalse();
+    }
+
+    @Test
+    void fedrekvote_rundt_termin_blir_innvilget() {
+        var termindato = LocalDate.of(2022, 10, 1);
+
+        var oppgittPeriode = oppgittPeriode(termindato.minusDays(3), termindato.plusWeeks(1).plusDays(1));
+        var grunnlag = basicGrunnlag(termindato)
+                .behandling(new Behandling.Builder().søkerErMor(false))
+                .søknad(søknad(oppgittPeriode))
+                .datoer(new Datoer.Builder().termin(termindato))
+                .kontoer(fedrekvoteKonto(10 * 5).farUttakRundtFødselDager(10))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertThat(regelresultat.oppfylt()).isTrue();
+    }
+
 
     private void assertInnvilgetOpphold(FastsettePerioderRegelresultat regelresultat) {
         assertThat(regelresultat.oppfylt()).isTrue();

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
@@ -362,7 +362,7 @@ class FedrekvoteDelregelTest {
     }
 
     @Test
-    void fedrekvote_rundt_fødsel__for_mange_dager_blir_avslått() {
+    void fedrekvote_rundt_fødsel_for_mange_dager_blir_avslått() {
         var fødselsdato = LocalDate.of(2022, 10, 3);
         var termindato = LocalDate.of(2022, 10, 5);
 

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteDelregelTest.java
@@ -362,10 +362,28 @@ class FedrekvoteDelregelTest {
     }
 
     @Test
-    void fedrekvote_rundt_fødsel__men_før_fødsel_blir_avslått() {
+    void fedrekvote_rundt_fødsel__for_mange_dager_blir_avslått() {
+        var fødselsdato = LocalDate.of(2022, 10, 3);
+        var termindato = LocalDate.of(2022, 10, 5);
+
+        var oppgittPeriode = oppgittPeriode(fødselsdato, termindato.plusWeeks(2).plusDays(1));
+        var grunnlag = basicGrunnlag(fødselsdato)
+                .datoer(new Datoer.Builder().termin(termindato).fødsel(fødselsdato))
+                .behandling(new Behandling.Builder().søkerErMor(false))
+                .søknad(søknad(oppgittPeriode))
+                .kontoer(fedrekvoteKonto(10 * 5).farUttakRundtFødselDager(10))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertThat(regelresultat.oppfylt()).isFalse();
+    }
+
+    @Test
+    void fedrekvote_rundt_fødsel_uten_termin_periode_før_fødsel_blir_avslått() {
         var fødselsdato = LocalDate.of(2022, 10, 1);
 
-        var oppgittPeriode = oppgittPeriode(fødselsdato.minusDays(2), fødselsdato.plusWeeks(1).plusDays(1));
+        var oppgittPeriode = oppgittPeriode(fødselsdato.minusDays(2), fødselsdato.minusDays(1));
         var grunnlag = basicGrunnlag(fødselsdato)
                 .behandling(new Behandling.Builder().søkerErMor(false))
                 .søknad(søknad(oppgittPeriode))
@@ -381,7 +399,7 @@ class FedrekvoteDelregelTest {
     void fedrekvote_rundt_termin_blir_innvilget() {
         var termindato = LocalDate.of(2022, 10, 1);
 
-        var oppgittPeriode = oppgittPeriode(termindato.minusDays(3), termindato.plusWeeks(1).plusDays(1));
+        var oppgittPeriode = oppgittPeriode(termindato.minusDays(3), termindato.minusDays(1));
         var grunnlag = basicGrunnlag(termindato)
                 .behandling(new Behandling.Builder().søkerErMor(false))
                 .søknad(søknad(oppgittPeriode))

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FedrekvoteOrkestreringTest.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.AVSLÅTT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.INNVILGET;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.MANUELL_BEHANDLING;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype.FEDREKVOTE;
@@ -249,23 +250,6 @@ class FedrekvoteOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
     }
 
     @Test
-    void fedrekvote_med_uttak_rundt_fødsel_blir_avkortet_og_innvilget_riktig() {
-        var fødselsdato = LocalDate.of(2022, 10, 3);
-        var grunnlag = basicGrunnlagFar(fødselsdato)
-                .kontoer(new Kontoer.Builder().konto(new Konto.Builder().type(FEDREKVOTE).trekkdager(15*5)).farUttakRundtFødselDager(10))
-                .søknad(søknad(Søknadstype.FØDSEL,
-                        oppgittPeriode(fødselsdato.minusWeeks(1), fødselsdato.plusWeeks(3).minusDays(1), PeriodeVurderingType.IKKE_VURDERT)));
-
-        var resultater = fastsettPerioder(grunnlag);
-
-        assertThat(resultater).hasSize(3);
-
-        verifiserPeriode(resultater.get(0).getUttakPeriode(), fødselsdato.minusWeeks(1), fødselsdato.minusDays(1), MANUELL_BEHANDLING, FEDREKVOTE);
-        verifiserPeriode(resultater.get(1).getUttakPeriode(), fødselsdato, fødselsdato.plusWeeks(2).minusDays(1), INNVILGET, FEDREKVOTE);
-        verifiserPeriode(resultater.get(2).getUttakPeriode(), fødselsdato.plusWeeks(2), fødselsdato.plusWeeks(3).minusDays(1), MANUELL_BEHANDLING, FEDREKVOTE);
-    }
-
-    @Test
     void fedrekvote_med_enkelt_uttak_rundt_fødsel_blir_avkortet_og_innvilget_riktig() {
         var fødselsdato = LocalDate.of(2022, 10, 3);
         var grunnlag = basicGrunnlagFar(fødselsdato)
@@ -280,6 +264,44 @@ class FedrekvoteOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
 
         verifiserPeriode(resultater.get(0).getUttakPeriode(), fødselsdato, fødselsdato.plusWeeks(1).minusDays(1), INNVILGET, FEDREKVOTE);
         verifiserPeriode(resultater.get(1).getUttakPeriode(), fødselsdato.plusWeeks(31), fødselsdato.plusWeeks(40).minusDays(1), INNVILGET, FEDREKVOTE);
+    }
+
+    @Test
+    void fedrekvote_med_enkelt_uttak_rundt_termin_blir_avkortet_og_innvilget_riktig() {
+        var fødselsdato = LocalDate.of(2022, 10, 4);
+        var termindato = fødselsdato.plusDays(1);
+        var grunnlag = basicGrunnlagFar(fødselsdato)
+                .datoer(datoer(fødselsdato).termin(termindato))
+                .kontoer(new Kontoer.Builder().konto(new Konto.Builder().type(FEDREKVOTE).trekkdager(15*5)).farUttakRundtFødselDager(10))
+                .søknad(søknad(Søknadstype.FØDSEL,
+                        oppgittPeriode(termindato.minusDays(2), termindato.plusWeeks(2).minusDays(3), PeriodeVurderingType.IKKE_VURDERT),
+                        oppgittPeriode(fødselsdato.plusWeeks(31), fødselsdato.plusWeeks(50).minusDays(1), PeriodeVurderingType.IKKE_VURDERT)));
+
+        var resultater = fastsettPerioder(grunnlag);
+
+        assertThat(resultater).hasSize(4);
+
+        verifiserPeriode(resultater.get(0).getUttakPeriode(), termindato.minusDays(2), fødselsdato.minusDays(1), INNVILGET, FEDREKVOTE);
+        verifiserPeriode(resultater.get(1).getUttakPeriode(), fødselsdato, termindato.plusWeeks(2).minusDays(3), INNVILGET, FEDREKVOTE);
+        verifiserPeriode(resultater.get(2).getUttakPeriode(), fødselsdato.plusWeeks(31), fødselsdato.plusWeeks(44).minusDays(1), INNVILGET, FEDREKVOTE);
+        verifiserPeriode(resultater.get(3).getUttakPeriode(), fødselsdato.plusWeeks(44), fødselsdato.plusWeeks(50).minusDays(1), AVSLÅTT, FEDREKVOTE);
+    }
+
+    @Test
+    void fedrekvote_med_uttak_rundt_fødsel_blir_avkortet_og_innvilget_riktig() {
+        var fødselsdato = LocalDate.of(2022, 10, 3);
+        var grunnlag = basicGrunnlagFar(fødselsdato)
+                .kontoer(new Kontoer.Builder().konto(new Konto.Builder().type(FEDREKVOTE).trekkdager(15*5)).farUttakRundtFødselDager(10))
+                .søknad(søknad(Søknadstype.FØDSEL,
+                        oppgittPeriode(fødselsdato.minusWeeks(1), fødselsdato.plusWeeks(3).minusDays(1), PeriodeVurderingType.IKKE_VURDERT)));
+
+        var resultater = fastsettPerioder(grunnlag);
+
+        assertThat(resultater).hasSize(3);
+
+        verifiserPeriode(resultater.get(0).getUttakPeriode(), fødselsdato.minusWeeks(1), fødselsdato.minusDays(1), MANUELL_BEHANDLING, FEDREKVOTE);
+        verifiserPeriode(resultater.get(1).getUttakPeriode(), fødselsdato, fødselsdato.plusWeeks(2).minusDays(1), INNVILGET, FEDREKVOTE);
+        verifiserPeriode(resultater.get(2).getUttakPeriode(), fødselsdato.plusWeeks(2), fødselsdato.plusWeeks(3).minusDays(1), MANUELL_BEHANDLING, FEDREKVOTE);
     }
 
     private OppgittPeriode overføringPeriode(Stønadskontotype stønadskontotype,

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
@@ -709,6 +709,58 @@ class ForeldrepengerDelregelTest {
         assertInnvilget(regelresultat, InnvilgetÅrsak.GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, "UT1318");
     }
 
+    @Test
+    void bfhr_rundt_fødsel_blir_innvilget() {
+        var fødselsdato = LocalDate.of(2022, 10, 1);
+
+        var oppgittPeriode = oppgittPeriode(fødselsdato, fødselsdato.plusWeeks(1).plusDays(1));
+        var grunnlag = grunnlagFar(fødselsdato)
+                .behandling(new Behandling.Builder().søkerErMor(false).kreverSammenhengendeUttak(false))
+                .søknad(søknad(oppgittPeriode))
+                .rettOgOmsorg(new RettOgOmsorg.Builder().morHarRett(false).farHarRett(true).aleneomsorg(false))
+                .kontoer(foreldrepengerKonto(40 * 5).farUttakRundtFødselDager(10).minsterettDager(10))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertThat(regelresultat.oppfylt()).isTrue();
+    }
+
+    @Test
+    void bfhr_rundt_fødsel_men_før_fødsel_blir_avslått() {
+        var fødselsdato = LocalDate.of(2022, 10, 1);
+
+        var oppgittPeriode = oppgittPeriode(fødselsdato.minusDays(2), fødselsdato.plusWeeks(1).plusDays(1));
+        var grunnlag = grunnlagFar(fødselsdato)
+                .behandling(new Behandling.Builder().søkerErMor(false).kreverSammenhengendeUttak(false))
+                .søknad(søknad(oppgittPeriode))
+                .rettOgOmsorg(new RettOgOmsorg.Builder().morHarRett(false).farHarRett(true).aleneomsorg(false))
+                .kontoer(foreldrepengerKonto(40 * 5).farUttakRundtFødselDager(10).minsterettDager(10))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertThat(regelresultat.oppfylt()).isFalse();
+    }
+
+    @Test
+    void bfhr_rundt_termin_blir_innvilget() {
+        var termindato = LocalDate.of(2022, 10, 1);
+
+        var oppgittPeriode = oppgittPeriode(termindato.minusDays(3), termindato.plusWeeks(1).plusDays(1));
+        var grunnlag = grunnlagFar(termindato)
+                .behandling(new Behandling.Builder().søkerErMor(false).kreverSammenhengendeUttak(false))
+                .søknad(søknad(oppgittPeriode))
+                .rettOgOmsorg(new RettOgOmsorg.Builder().morHarRett(false).farHarRett(true).aleneomsorg(false))
+                .datoer(new Datoer.Builder().termin(termindato))
+                .kontoer(foreldrepengerKonto(40 * 5).farUttakRundtFødselDager(10).minsterettDager(10))
+                .build();
+
+        var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
+
+        assertThat(regelresultat.oppfylt()).isTrue();
+    }
+
     private void assertInnvilget(FastsettePerioderRegelresultat regelresultat, InnvilgetÅrsak innvilgetÅrsak) {
         assertThat(regelresultat.oppfylt()).isTrue();
         assertThat(regelresultat.skalUtbetale()).isTrue();

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/RegelResultatBehandlerTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/RegelResultatBehandlerTest.java
@@ -38,7 +38,8 @@ class RegelResultatBehandlerTest {
         var knekkpunkt = new TomKontoKnekkpunkt(LocalDate.of(2018, 10, 15));
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(), List.of(), grunnlag.getKontoer(),
                 oppgittPeriode.getFom(), grunnlag.getArbeid().getAktiviteter(), grunnlag.getSøknad().getMottattTidspunkt(),
-                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt());
+                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt(),
+                FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(grunnlag, StandardKonfigurasjon.KONFIGURASJON));
         oppgittPeriode.setAktiviteter(Set.of(arbeidsforhold.getIdentifikator()));
         var behandler = new RegelResultatBehandler(SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag), grunnlag,
                 StandardKonfigurasjon.KONFIGURASJON);

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/SaldoUtregningTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/SaldoUtregningTjenesteTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +48,7 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Utbetalingsg
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregningGrunnlag;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregningTjeneste;
 import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
+import no.nav.foreldrepenger.regler.uttak.konfig.StandardKonfigurasjon;
 
 class SaldoUtregningTjenesteTest {
 
@@ -195,12 +197,14 @@ class SaldoUtregningTjenesteTest {
         if (grunnlag.getBehandling().isBerørtBehandling()) {
             return SaldoUtregningGrunnlag.forUtregningAvDelerAvUttakBerørtBehandling(List.of(),
                     grunnlag.getAnnenPart().getUttaksperioder(), grunnlag.getKontoer(), aktuellPeriode.getFom(),
-                    new ArrayList<>(grunnlag.getSøknad().getOppgittePerioder()), grunnlag.getArbeid().getAktiviteter());
+                    new ArrayList<>(grunnlag.getSøknad().getOppgittePerioder()), grunnlag.getArbeid().getAktiviteter(),
+                    FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(grunnlag, StandardKonfigurasjon.KONFIGURASJON));
         }
         return SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(), grunnlag.getAnnenPart().getUttaksperioder(),
                 grunnlag.getKontoer(), aktuellPeriode.getFom(), grunnlag.getArbeid().getAktiviteter(),
                 grunnlag.getSøknad().getMottattTidspunkt(),
-                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt());
+                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt(),
+                FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(grunnlag, StandardKonfigurasjon.KONFIGURASJON));
     }
 
     @Test
@@ -261,7 +265,8 @@ class SaldoUtregningTjenesteTest {
                 .aktiviteter(List.of(new FastsattUttakPeriodeAktivitet(new Trekkdager(2.5), FELLESPERIODE, identifikator)))
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(fastsattPeriode), List.of(),
-                kontoer.build(), utregningsdato, Set.of(identifikator, identifikatorNyttArbeidsforhold), null, null);
+                kontoer.build(), utregningsdato, Set.of(identifikator, identifikatorNyttArbeidsforhold), null, null,
+                Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(FELLESPERIODE, identifikator)).isEqualTo(new Trekkdager(97.5));
@@ -287,7 +292,7 @@ class SaldoUtregningTjenesteTest {
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(fastsattPeriode),
                 List.of(annenpartsPeriode), kontoer.build(), utregningsdato, Set.of(identifikator, identifikatorNyttArbeidsforhold),
-                null, null);
+                null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(MØDREKVOTE, identifikator)).isEqualTo(Trekkdager.ZERO);
@@ -320,7 +325,7 @@ class SaldoUtregningTjenesteTest {
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(fastsattPeriode),
                 List.of(annenpartsPeriode), kontoer.build(), utregningsdato, Set.of(identifikator, identifikatorNyttArbeidsforhold),
-                null, null);
+                null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(MØDREKVOTE, identifikator)).isEqualTo(new Trekkdager(14*5));
@@ -356,7 +361,7 @@ class SaldoUtregningTjenesteTest {
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(fastsattPeriode),
                 List.of(annenpartsPeriode), kontoer.build(), utregningsdato, Set.of(identifikator, identifikatorNyttArbeidsforhold),
-                null, null);
+                null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.restSaldoFlerbarnsdager(identifikator)).isEqualTo(new Trekkdager(16*5));
@@ -389,7 +394,7 @@ class SaldoUtregningTjenesteTest {
                         new AnnenpartUttakPeriodeAktivitet(forSelvstendigNæringsdrivende(), FELLESPERIODE, new Trekkdager(5), Utbetalingsgrad.HUNDRED)))
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(fastsattPeriode),
-                true, List.of(annenpartsPeriode), kontoer.build(), null, null);
+                true, List.of(annenpartsPeriode), kontoer.build(), null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.restSaldoFlerbarnsdager(identifikator)).isEqualTo(new Trekkdager(16*5));
@@ -420,7 +425,7 @@ class SaldoUtregningTjenesteTest {
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(avslåttPeriode, innvilgetPeriode),
                 List.of(), kontoer.build(), utregningsdato, Set.of(identifikator),
-                null, null);
+                null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(FORELDREPENGER, identifikator)).isEqualTo(foreldrepengerTD.subtract(mspTD).subtract(innvilgetMinsterettTD));
@@ -449,7 +454,7 @@ class SaldoUtregningTjenesteTest {
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(avslåttPeriode, innvilgetPeriode),
                 List.of(), kontoer.build(), utregningsdato, Set.of(identifikator),
-                null, null);
+                null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(FORELDREPENGER, identifikator)).isEqualTo(Trekkdager.ZERO);
@@ -482,7 +487,7 @@ class SaldoUtregningTjenesteTest {
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(avslåttPeriode, innvilgetPeriode1, innvilgetPeriode2),
                 List.of(), kontoer.build(), utregningsdato, Set.of(identifikator),
-                null, null);
+                null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(FORELDREPENGER, identifikator)).isEqualTo(Trekkdager.ZERO);
@@ -506,7 +511,7 @@ class SaldoUtregningTjenesteTest {
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(innvilgetPeriode),
                 List.of(), kontoer.build(), utregningsdato, Set.of(identifikator),
-                null, null);
+                null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(FORELDREPENGER, identifikator)).isEqualTo(new Trekkdager(200-50 ));
@@ -540,7 +545,7 @@ class SaldoUtregningTjenesteTest {
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(
                 List.of(fastsattPeriode1, fastsattPeriode2, fastsattPeriode3), List.of(), kontoer.build(), utregningsdato,
-                Set.of(identifikator, identifikatorNyttArbeidsforhold1, identifikatorNyttArbeidsforhold2), null, null);
+                Set.of(identifikator, identifikatorNyttArbeidsforhold1, identifikatorNyttArbeidsforhold2), null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(FELLESPERIODE, identifikator)).isEqualTo(new Trekkdager(5));
@@ -574,7 +579,7 @@ class SaldoUtregningTjenesteTest {
                         Utbetalingsgrad.HUNDRED))
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(fastsattPeriode), false,
-                List.of(annenpartPeriode1, annenpartPeriode2), kontoer.build(), null, null);
+                List.of(annenpartPeriode1, annenpartPeriode2), kontoer.build(), null, null, Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(FELLESPERIODE, søkersArbeidsforhold)).isEqualTo(new Trekkdager(97));
@@ -614,7 +619,7 @@ class SaldoUtregningTjenesteTest {
         var grunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(opphold, uttakEtterOpphold), false,
                 List.of(annenpartUttaksperiode1, annenpartUttaksperiode2, annenpartUttaksperiode3), kontoer.build(),
                 LocalDateTime.of(annenpartUttaksperiode1.getFom(), LocalTime.NOON),
-                LocalDateTime.of(opphold.getFom(), LocalTime.NOON));
+                LocalDateTime.of(opphold.getFom(), LocalTime.NOON), Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(grunnlag);
 
         //100 - 25 - 25 - 25 - 1
@@ -641,7 +646,7 @@ class SaldoUtregningTjenesteTest {
         var grunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(opphold, uttakEtterOpphold), false,
                 List.of(annenpartUttaksperiode), kontoer.build(),
                 LocalDateTime.of(annenpartUttaksperiode.getFom(), LocalTime.NOON),
-                LocalDateTime.of(opphold.getFom(), LocalTime.NOON));
+                LocalDateTime.of(opphold.getFom(), LocalTime.NOON), Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(grunnlag);
 
         //100 - 3 - 2 - 1
@@ -673,7 +678,7 @@ class SaldoUtregningTjenesteTest {
         var grunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(opphold, uttakEtterOpphold), false,
                 List.of(annenpartUttaksperiode1, annenpartUttaksperiode2), kontoer.build(),
                 LocalDateTime.of(annenpartUttaksperiode1.getFom(), LocalTime.NOON),
-                LocalDateTime.of(opphold.getFom(), LocalTime.NOON));
+                LocalDateTime.of(opphold.getFom(), LocalTime.NOON), Optional.empty());
         var resultat = SaldoUtregningTjeneste.lagUtregning(grunnlag);
 
         //100 - 2 - 2 - 1 - 1

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/TapendeSakOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/TapendeSakOrkestreringTest.java
@@ -259,6 +259,68 @@ class TapendeSakOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
         assertThat(resultatPeriode.getPerioderesultattype()).isEqualTo(INNVILGET);
     }
 
+    @Test
+    void skal_evaluere_normal_flyt_dersom_far_rundt_fødsel_berørt_med_samtidig() {
+        //Søkt samme dag, men mor har søkt etter far
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 10, 3));
+        var termindato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 10, 5));
+        var grunnlag = RegelGrunnlagTestBuilder.create()
+                .datoer(new Datoer.Builder().fødsel(fødselsdato).termin(termindato))
+                .annenPart(new AnnenPart.Builder()
+                        .uttaksperiode(annenpartsPeriode(MØDREKVOTE, fødselsdato, fødselsdato.plusWeeks(10).minusDays(1), MOR_ARBEIDSFORHOLD, true, fødselsdato))
+                        .uttaksperiode(annenpartsPeriode(MØDREKVOTE, fødselsdato.plusWeeks(10), fødselsdato.plusWeeks(12), MOR_ARBEIDSFORHOLD, true, fødselsdato))
+                )
+                .behandling(farBehandling().berørtBehandling(true))
+                .rettOgOmsorg(beggeRett())
+                .kontoer(new Kontoer.Builder()
+                        .konto(new Konto.Builder().type(MØDREKVOTE).trekkdager(5*15))
+                        .konto(new Konto.Builder().type(FEDREKVOTE).trekkdager(5*15))
+                        .konto(new Konto.Builder().type(FELLESPERIODE).trekkdager(5*16))
+                        .farUttakRundtFødselDager(10))
+                .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
+                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FEDREKVOTE, termindato.minusWeeks(1), termindato.plusWeeks(1).minusDays(1),
+                                new SamtidigUttaksprosent(100), false, PeriodeVurderingType.IKKE_VURDERT, fødselsdato, fødselsdato,
+                                null))
+                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FEDREKVOTE, fødselsdato.plusWeeks(35), fødselsdato.plusWeeks(42).minusDays(1),
+                                null, false, PeriodeVurderingType.IKKE_VURDERT, fødselsdato, fødselsdato,
+                                null))
+                );
+
+        var resultat = fastsettPerioder(grunnlag);
+
+        assertThat(resultat).hasSize(3);
+        assertThat(resultat.stream().map(FastsettePeriodeResultat::getUttakPeriode).map(UttakPeriode::getPerioderesultattype).allMatch(INNVILGET::equals)).isTrue();
+    }
+
+    @Test
+    void skal_evaluere_normal_flyt_dersom_far_rundt_fødsel_mor_berørt_behandling_annen_part_samtidig() {
+        //Søkt samme dag, men mor har søkt etter far
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 10, 3));
+        var termindato = Virkedager.justerHelgTilMandag(LocalDate.of(2022, 10, 5));
+        var grunnlag = RegelGrunnlagTestBuilder.create()
+                .datoer(new Datoer.Builder().fødsel(fødselsdato).termin(termindato))
+                .annenPart(new AnnenPart.Builder()
+                        .uttaksperiode(annenpartsSamtidigPeriode(FEDREKVOTE, termindato.minusWeeks(1), termindato.plusWeeks(1).minusDays(1), MOR_ARBEIDSFORHOLD, true, fødselsdato))
+                        .uttaksperiode(annenpartsSamtidigPeriode(FEDREKVOTE, fødselsdato.plusWeeks(41), fødselsdato.plusWeeks(50).minusDays(1), MOR_ARBEIDSFORHOLD, true, fødselsdato))
+                )
+                .behandling(morBehandling().berørtBehandling(true))
+                .rettOgOmsorg(beggeRett())
+                .kontoer(new Kontoer.Builder()
+                        .konto(new Konto.Builder().type(MØDREKVOTE).trekkdager(5*15))
+                        .konto(new Konto.Builder().type(FELLESPERIODE).trekkdager(5*16))
+                        .konto(new Konto.Builder().type(FEDREKVOTE).trekkdager(5*15))
+                        .farUttakRundtFødselDager(10))
+                .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
+                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(MØDREKVOTE, fødselsdato, fødselsdato.plusWeeks(10).minusDays(3),
+                                null, false, PeriodeVurderingType.IKKE_VURDERT, fødselsdato, fødselsdato, null))
+                );
+
+        var resultat = fastsettPerioder(grunnlag);
+
+        assertThat(resultat).hasSize(3);
+        assertThat(resultat.stream().map(FastsettePeriodeResultat::getUttakPeriode).map(UttakPeriode::getPerioderesultattype).allMatch(INNVILGET::equals)).isTrue();
+    }
+
     static AnnenpartUttakPeriode annenpartsPeriode(Stønadskontotype stønadskontotype,
                                                    LocalDate fom,
                                                    LocalDate tom,
@@ -277,6 +339,21 @@ class TapendeSakOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
                 .uttakPeriodeAktivitet(new AnnenpartUttakPeriodeAktivitet(aktivitet, stønadskontotype,
                         new Trekkdager(Virkedager.beregnAntallVirkedager(fom, tom)), Utbetalingsgrad.TEN))
                 .innvilget(innvilget)
+                .senestMottattDato(senestMottattDato)
+                .build();
+    }
+
+    static AnnenpartUttakPeriode annenpartsSamtidigPeriode(Stønadskontotype stønadskontotype,
+                                                   LocalDate fom,
+                                                   LocalDate tom,
+                                                   AktivitetIdentifikator aktivitet,
+                                                   boolean innvilget,
+                                                   LocalDate senestMottattDato) {
+        return AnnenpartUttakPeriode.Builder.uttak(fom, tom)
+                .uttakPeriodeAktivitet(new AnnenpartUttakPeriodeAktivitet(aktivitet, stønadskontotype,
+                        new Trekkdager(Virkedager.beregnAntallVirkedager(fom, tom)), Utbetalingsgrad.TEN))
+                .innvilget(innvilget)
+                .samtidigUttak(true)
                 .senestMottattDato(senestMottattDato)
                 .build();
     }

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmDelerAvPeriodenHarGyldigGrunnTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmDelerAvPeriodenHarGyldigGrunnTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,10 +15,10 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Dokumentasjo
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.GyldigGrunnPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RegelGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknad;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregningGrunnlag;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregningTjeneste;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.evaluation.Resultat;
 
@@ -111,7 +112,7 @@ class SjekkOmDelerAvPeriodenHarGyldigGrunnTest {
     private Evaluation evaluer(OppgittPeriode søknadsperiode, RegelGrunnlag grunnlag) {
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(), List.of(), grunnlag.getKontoer(),
                 søknadsperiode.getFom(), grunnlag.getArbeid().getAktiviteter(), grunnlag.getSøknad().getMottattTidspunkt(),
-                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt());
+                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt(), Optional.empty());
         return new SjekkOmDelerAvPeriodenHarGyldigGrunn().evaluate(
                 new FastsettePeriodeGrunnlagImpl(grunnlag, SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag),
                         søknadsperiode));

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmTomForAlleSineKontoerTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmTomForAlleSineKontoerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,11 +20,11 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPerio
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeVurderingType;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RegelGrunnlag;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RettOgOmsorg;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknad;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknadstype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregningGrunnlag;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregningTjeneste;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.fpsak.nare.evaluation.Resultat;
 
 class SjekkOmTomForAlleSineKontoerTest {
@@ -66,7 +67,7 @@ class SjekkOmTomForAlleSineKontoerTest {
         var sjekkOmTomForAlleSineKontoer = new SjekkOmTomForAlleSineKontoer();
         uttakPeriode.setAktiviteter(grunnlag.getArbeid().getAktiviteter());
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(), List.of(), kontoer.build(),
-                uttakPeriode.getFom(), grunnlag.getArbeid().getAktiviteter(), periodeStart.atStartOfDay(), null);
+                uttakPeriode.getFom(), grunnlag.getArbeid().getAktiviteter(), periodeStart.atStartOfDay(), null, Optional.empty());
         var evaluation = sjekkOmTomForAlleSineKontoer.evaluate(
                 new FastsettePeriodeGrunnlagImpl(grunnlag, SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag), uttakPeriode));
         assertThat(evaluation.result()).isEqualTo(Resultat.NEI);

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppholdÅrsa
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Orgnummer;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
+import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.LukketPeriode;
 
 class SaldoUtregningTest {
 
@@ -138,7 +140,8 @@ class SaldoUtregningTest {
                 .build();
         var perioderSøker = List.of(fastsattUttakPeriode1, fastsattUttakPeriode2);
         var saldoUtregning = new SaldoUtregning(Set.of(stønadskonto(FORELDREPENGER, 15)), perioderSøker, List.of(), false,
-                Set.of(AKTIVITET1_SØKER), null, null, new Trekkdager(10), new Trekkdager(10), Trekkdager.ZERO);
+                Set.of(AKTIVITET1_SØKER), null, null,
+                Trekkdager.ZERO, new Trekkdager(10), Trekkdager.ZERO, Optional.empty(), Trekkdager.ZERO);
         assertThat(saldoUtregning.restSaldoDagerUtenAktivitetskrav(AKTIVITET1_SØKER)).isEqualTo(new Trekkdager(7));
         assertThat(saldoUtregning.saldo(FORELDREPENGER)).isEqualTo(2);
         assertThat(saldoUtregning.getMaxDagerUtenAktivitetskrav()).isEqualTo(new Trekkdager(10));
@@ -156,7 +159,8 @@ class SaldoUtregningTest {
                 .build();
         var perioderSøker = List.of(fastsattUttakPeriode);
         var saldoUtregning = new SaldoUtregning(Set.of(stønadskonto(FORELDREPENGER, 10)), perioderSøker, List.of(), false,
-                Set.of(AKTIVITET1_SØKER), null, null, new Trekkdager(5), Trekkdager.ZERO, Trekkdager.ZERO);
+                Set.of(AKTIVITET1_SØKER), null, null,
+                new Trekkdager(5), Trekkdager.ZERO, Trekkdager.ZERO, Optional.empty(), Trekkdager.ZERO);
         // Skal beholde dager pga minsterett 5 derfor 5-15
         assertThat(saldoUtregning.nettoSaldoJustertForMinsterett(FORELDREPENGER, AKTIVITET1_SØKER, false).decimalValue().intValue()).isEqualTo(5-15);
         assertThat(saldoUtregning.nettoSaldoJustertForMinsterett(FORELDREPENGER, AKTIVITET1_SØKER, true).decimalValue().intValue()).isEqualTo(10-15);
@@ -180,7 +184,8 @@ class SaldoUtregningTest {
                 .build();
         var perioderSøker = List.of(fastsattUttakPeriode);
         var saldoUtregning = new SaldoUtregning(Set.of(stønadskonto(FORELDREPENGER, 10)), perioderSøker, List.of(), false,
-                Set.of(AKTIVITET1_SØKER), null, null, new Trekkdager(5), Trekkdager.ZERO, Trekkdager.ZERO);
+                Set.of(AKTIVITET1_SØKER), null, null,
+                new Trekkdager(5), Trekkdager.ZERO, Trekkdager.ZERO, Optional.empty(), Trekkdager.ZERO);
         // Skal forbruke minsterett
         assertThat(saldoUtregning.nettoSaldoJustertForMinsterett(FORELDREPENGER, AKTIVITET1_SØKER, false).decimalValue().intValue()).isEqualTo(10-15);
         assertThat(saldoUtregning.nettoSaldoJustertForMinsterett(FORELDREPENGER, AKTIVITET1_SØKER, true).decimalValue().intValue()).isEqualTo(10-15);
@@ -205,7 +210,8 @@ class SaldoUtregningTest {
                 .build();
         var perioderSøker = List.of(fastsattUttakPeriode);
         var saldoUtregning = new SaldoUtregning(Set.of(stønadskonto(FORELDREPENGER, 10)), perioderSøker, List.of(), false,
-                Set.of(AKTIVITET1_SØKER), null, null, Trekkdager.ZERO, new Trekkdager(5), Trekkdager.ZERO);
+                Set.of(AKTIVITET1_SØKER), null, null,
+                Trekkdager.ZERO, new Trekkdager(5), Trekkdager.ZERO, Optional.empty(), Trekkdager.ZERO);
         // Skal beholde dager pga minsterett 5 derfor 5-15
         assertThat(saldoUtregning.nettoSaldoJustertForMinsterett(FORELDREPENGER, AKTIVITET1_SØKER, false).decimalValue().intValue()).isEqualTo(10-15);
         assertThat(saldoUtregning.nettoSaldoJustertForMinsterett(FORELDREPENGER, AKTIVITET1_SØKER, true).decimalValue().intValue()).isEqualTo(10-15);
@@ -229,7 +235,8 @@ class SaldoUtregningTest {
                 .build();
         var perioderSøker = List.of(fastsattUttakPeriode);
         var saldoUtregning = new SaldoUtregning(Set.of(stønadskonto(FORELDREPENGER, 10)), perioderSøker, List.of(), false,
-                Set.of(AKTIVITET1_SØKER), null, null, Trekkdager.ZERO, new Trekkdager(5), Trekkdager.ZERO);
+                Set.of(AKTIVITET1_SØKER), null, null,
+                Trekkdager.ZERO, new Trekkdager(5), Trekkdager.ZERO, Optional.empty(), Trekkdager.ZERO);
         // Skal forbruke minsterett
         assertThat(saldoUtregning.nettoSaldoJustertForMinsterett(FORELDREPENGER, AKTIVITET1_SØKER, false).decimalValue().intValue()).isEqualTo(10-15);
         assertThat(saldoUtregning.nettoSaldoJustertForMinsterett(FORELDREPENGER, AKTIVITET1_SØKER, true).decimalValue().intValue()).isEqualTo(10-15);
@@ -237,6 +244,40 @@ class SaldoUtregningTest {
         assertThat(saldoUtregning.restSaldoDagerUtenAktivitetskrav(AKTIVITET1_SØKER)).isEqualTo(new Trekkdager(-10));
         assertThat(saldoUtregning.saldo(FORELDREPENGER, AKTIVITET1_SØKER)).isEqualTo(10 - 15);
         assertThat(saldoUtregning.saldo(FORELDREPENGER)).isEqualTo(10 - 15);
+    }
+
+    @Test
+    void vanlig_far_fødsel_gir_riktig_saldo_far_fødsel() {
+        var fastsattUttakPeriode = new FastsattUttakPeriode.Builder()
+                .aktiviteter(List.of(new FastsattUttakPeriodeAktivitet(new Trekkdager(5), FEDREKVOTE, AKTIVITET1_SØKER)))
+                .periodeResultatType(Perioderesultattype.INNVILGET)
+                .tidsperiode(enTirsdag, enTirsdag)
+                .resultatÅrsak(FastsattUttakPeriode.ResultatÅrsak.ANNET)
+                .build();
+        var perioderSøker = List.of(fastsattUttakPeriode);
+        var saldoUtregning = new SaldoUtregning(Set.of(stønadskonto(FEDREKVOTE, 10)), perioderSøker, List.of(), false,
+                Set.of(AKTIVITET1_SØKER), null, null, Trekkdager.ZERO, Trekkdager.ZERO, Trekkdager.ZERO,
+                Optional.of(new LukketPeriode(enTirsdag, enTirsdag)), new Trekkdager(10));
+        // Skal forbruke minsterett
+        assertThat(saldoUtregning.restSaldoFarUttakRundtFødsel(AKTIVITET1_SØKER)).isEqualTo(new Trekkdager(5));
+        assertThat(saldoUtregning.restSaldoFarUttakRundtFødsel()).isEqualTo(new Trekkdager(5));
+    }
+
+    @Test
+    void for_stort_trekk_far_fødsel_gir_riktig_saldo_far_fødsel() {
+        var fastsattUttakPeriode = new FastsattUttakPeriode.Builder()
+                .aktiviteter(List.of(new FastsattUttakPeriodeAktivitet(new Trekkdager(15), FEDREKVOTE, AKTIVITET1_SØKER)))
+                .periodeResultatType(Perioderesultattype.INNVILGET)
+                .tidsperiode(enTirsdag, enTirsdag)
+                .resultatÅrsak(FastsattUttakPeriode.ResultatÅrsak.ANNET)
+                .build();
+        var perioderSøker = List.of(fastsattUttakPeriode);
+        var saldoUtregning = new SaldoUtregning(Set.of(stønadskonto(FEDREKVOTE, 10)), perioderSøker, List.of(), false,
+                Set.of(AKTIVITET1_SØKER), null, null, Trekkdager.ZERO, Trekkdager.ZERO, Trekkdager.ZERO,
+                Optional.of(new LukketPeriode(enTirsdag, enTirsdag)), new Trekkdager(10));
+        // Skal forbruke minsterett
+        assertThat(saldoUtregning.restSaldoFarUttakRundtFødsel(AKTIVITET1_SØKER)).isEqualTo(new Trekkdager(-5));
+        assertThat(saldoUtregning.restSaldoFarUttakRundtFødsel()).isEqualTo(new Trekkdager(-5));
     }
 
     @Test

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifisererTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifisererTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -16,11 +17,11 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Konto;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Kontoer;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeVurderingType;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknad;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregningGrunnlag;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.saldo.SaldoUtregningTjeneste;
 import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 
 class TomKontoIdentifisererTest {
 
@@ -69,7 +70,7 @@ class TomKontoIdentifisererTest {
 
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(), List.of(), grunnlag.getKontoer(),
                 oppgittPeriode.getFom(), grunnlag.getArbeid().getAktiviteter(), grunnlag.getSøknad().getMottattTidspunkt(),
-                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt());
+                grunnlag.getAnnenPart() == null ? null : grunnlag.getAnnenPart().getSisteSøknadMottattTidspunkt(), Optional.empty());
         var saldoUtregning = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
         var tomKontoKnekkpunkt = TomKontoIdentifiserer.identifiser(oppgittPeriode, List.of(ARBEIDSFORHOLD_1), saldoUtregning,
                 Stønadskontotype.MØDREKVOTE, true);


### PR DESCRIPTION
Regler for å innvilge 2 uker Fedrekvote eller Foreldrepenger for far/medmor i forbindelse med fødsel.
Regler for samtidig uttak av disse ukene.
Utvidet saldoutregning med støtte for dager ifm fødsel 

Review-spm rundt flerbarnsdager, utenAktKrav, minsterett og farRundtFødsel: 
* SaldoUtregning: Hvilke av de 4 "rettighetsdagene" trengs i fp-sak utenfor reglene? 
* SaldoUtregning: Skille innvortes/utvortes bruk av konfig/saldo/restsaldo bedre?

Notater til rydding av uttak:
* Få VTP og DEV opp til frittuttakdato = prod. 
* Vurdere en  Rettighetsdager-enum og SaldoUtregning-interface med disse - vs ekstern og regelintern bruk
* Standardisere restsaldo-utregning for ulike rettighetsdager ? Obs på nettoSaldo ifm minsterett
* Standardisere på 1 konfigurasjon og fjerne støtte for test-konfigurasjoner - dvs ut med konfigurasjon som regelparameter
* Flytte inn diverse parametre fra fpsak sin konto-konfig etter ikrafttredelse FAB