### PR TITLE
TFP-5032 bfhr kan ta ut første 6 uker

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlag.java
@@ -157,9 +157,16 @@ public interface FastsettePeriodeGrunnlag {
     boolean isMorRett();
 
     /**
+     * Tilfelle av BareFarRett og oppgitt at MorMottarUføretrygd, 14-14 tredje ledd
+     *
+     * @return true dersom oppgitt.
+     */
+    boolean isMorOppgittUføretrygd();
+
+    /**
      * Tilfelle av BareFarRett og MorMottarUføretrygd, 14-14 tredje ledd
      *
-     * @return true dersom rett.
+     * @return true dersom bare far rett og bekreftet uføretrygd.
      */
     boolean isBareFarHarRettMorUføretrygd();
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlagImpl.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlagImpl.java
@@ -155,6 +155,11 @@ public class FastsettePeriodeGrunnlagImpl implements FastsettePeriodeGrunnlag {
     }
 
     @Override
+    public boolean isMorOppgittUføretrygd() {
+        return regelGrunnlag.getRettOgOmsorg().getMorOppgittUføretrygd();
+    }
+
+    @Override
     public boolean isBareFarHarRettMorUføretrygd() {
         var rett = regelGrunnlag.getRettOgOmsorg();
         return rett.getFarHarRett() && !rett.getMorHarRett() && rett.getMorUføretrygd();

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
@@ -262,10 +262,10 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakSkjerFørDeFørsteUkene() {
         return rs.hvisRegel(SjekkOmUttakSkjerEtterDeFørsteUkene.ID, SjekkOmUttakSkjerEtterDeFørsteUkene.BESKRIVELSE)
                 .hvis(new SjekkOmUttakSkjerEtterDeFørsteUkene(konfigurasjon), sjekkFarUtenAleneomsorgHarDisponibleDager())
-                .ellers(sjekkOmUttakFørsteSeksUkerErFarRundtFødsel());
+                .ellers(sjekkOmUttakFørsteSeksUkerErFarMedFABalansertUttak());
     }
 
-    private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakFørsteSeksUkerErFarRundtFødsel() {
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakFørsteSeksUkerErFarMedFABalansertUttak() {
         return rs.hvisRegel(SjekkOmMinsterettBalansertUttak.ID, "Er det sak med minsterett for balansert uttak?")
                 .hvis(new SjekkOmMinsterettBalansertUttak(), sjekkFarUtenAleneomsorgHarDisponibleDager())
                 .ellers(sjekkOmGyldigGrunnForTidligOppstart());

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregel.java
@@ -4,7 +4,7 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkGyld
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBareFarHarRett;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmBareMorHarRett;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmErAleneomsorg;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmFamilieArbeidslivBalanse;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmMinsterettBalansertUttak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmFarsUttakRundtFødselTilgjengeligeDager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmGradertPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmMinsterettHarDisponibleDager;
@@ -266,8 +266,8 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakFørsteSeksUkerErFarRundtFødsel() {
-        return rs.hvisRegel(SjekkOmFarsUttakRundtFødselTilgjengeligeDager.ID, "Er det hjemlet fars uttak rundt fødsel?")
-                .hvis(new SjekkOmFamilieArbeidslivBalanse(), sjekkFarUtenAleneomsorgHarDisponibleDager())
+        return rs.hvisRegel(SjekkOmMinsterettBalansertUttak.ID, "Er det sak med minsterett for balansert uttak?")
+                .hvis(new SjekkOmMinsterettBalansertUttak(), sjekkFarUtenAleneomsorgHarDisponibleDager())
                 .ellers(sjekkOmGyldigGrunnForTidligOppstart());
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmFamilieArbeidslivBalanse.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmFamilieArbeidslivBalanse.java
@@ -1,0 +1,21 @@
+package no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser;
+
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunnlag;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+
+@RuleDocumentation(SjekkOmFamilieArbeidslivBalanse.ID)
+public class SjekkOmFamilieArbeidslivBalanse extends LeafSpecification<FastsettePeriodeGrunnlag> {
+
+    public static final String ID = "FP_VK 13.10";
+
+    public SjekkOmFamilieArbeidslivBalanse() {
+        super(ID);
+    }
+
+    @Override
+    public Evaluation evaluate(FastsettePeriodeGrunnlag grunnlag) {
+        return grunnlag.isSakMedMinsterett() ? ja() : nei();
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmMinsterettBalansertUttak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/SjekkOmMinsterettBalansertUttak.java
@@ -5,12 +5,12 @@ import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
 
-@RuleDocumentation(SjekkOmFamilieArbeidslivBalanse.ID)
-public class SjekkOmFamilieArbeidslivBalanse extends LeafSpecification<FastsettePeriodeGrunnlag> {
+@RuleDocumentation(SjekkOmMinsterettBalansertUttak.ID)
+public class SjekkOmMinsterettBalansertUttak extends LeafSpecification<FastsettePeriodeGrunnlag> {
 
     public static final String ID = "FP_VK 13.10";
 
-    public SjekkOmFamilieArbeidslivBalanse() {
+    public SjekkOmMinsterettBalansertUttak() {
         super(ID);
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmMorOppgittUføre.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmMorOppgittUføre.java
@@ -20,11 +20,13 @@ public class SjekkOmMorOppgittUføre extends LeafSpecification<FastsettePeriodeG
 
     @Override
     public Evaluation evaluate(FastsettePeriodeGrunnlag fastsettePeriodeGrunnlag) {
-        if (fastsettePeriodeGrunnlag.isBareFarHarRettMorUføretrygd()) {
+        if (fastsettePeriodeGrunnlag.isMorRett() || !fastsettePeriodeGrunnlag.isFarRett()) {
+            return nei();
+        }
+        if (fastsettePeriodeGrunnlag.isMorOppgittUføretrygd()) {
             return ja();
         }
         var morsAktivitetIPeriode = fastsettePeriodeGrunnlag.getAktuellPeriode().getMorsAktivitet();
-        return !fastsettePeriodeGrunnlag.isMorRett() && fastsettePeriodeGrunnlag.isFarRett() &&
-                Objects.equals(morsAktivitetIPeriode, MorsAktivitet.UFØRE) ? ja() : nei();
+        return Objects.equals(morsAktivitetIPeriode, MorsAktivitet.UFØRE) ? ja() : nei();
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmMorOppgittUføre.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmMorOppgittUføre.java
@@ -20,6 +20,9 @@ public class SjekkOmMorOppgittUføre extends LeafSpecification<FastsettePeriodeG
 
     @Override
     public Evaluation evaluate(FastsettePeriodeGrunnlag fastsettePeriodeGrunnlag) {
+        if (fastsettePeriodeGrunnlag.isBareFarHarRettMorUføretrygd()) {
+            return ja();
+        }
         var morsAktivitetIPeriode = fastsettePeriodeGrunnlag.getAktuellPeriode().getMorsAktivitet();
         return !fastsettePeriodeGrunnlag.isMorRett() && fastsettePeriodeGrunnlag.isFarRett() &&
                 Objects.equals(morsAktivitetIPeriode, MorsAktivitet.UFØRE) ? ja() : nei();

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/RettOgOmsorg.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/RettOgOmsorg.java
@@ -7,6 +7,7 @@ public final class RettOgOmsorg {
     private boolean samtykke;
     private boolean aleneomsorg;
     private boolean morUføretrygd;
+    private boolean morOppgittUføretrygd;
 
     private RettOgOmsorg() {
     }
@@ -29,6 +30,10 @@ public final class RettOgOmsorg {
 
     public boolean getMorUføretrygd() {
         return morUføretrygd;
+    }
+
+    public boolean getMorOppgittUføretrygd() {
+        return morOppgittUføretrygd;
     }
 
     public static class Builder {
@@ -56,6 +61,11 @@ public final class RettOgOmsorg {
 
         public Builder morUføretrygd(boolean morUføretrygd) {
             kladd.morUføretrygd = morUføretrygd;
+            return this;
+        }
+
+        public Builder morOppgittUføretrygd(boolean morOppgittUføretrygd) {
+            kladd.morOppgittUføretrygd = morOppgittUføretrygd;
             return this;
         }
 

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
@@ -11,9 +11,31 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.*;
 import org.junit.jupiter.api.Test;
 
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktivitetIdentifikator;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeid;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeidsforhold;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Behandling;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Datoer;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Dokumentasjon;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriodeAktivitet;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Inngangsvilkår;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Konto;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Kontoer;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.MorsAktivitet;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedAvklartMorsAktivitet;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeUtenOmsorg;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeVurderingType;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RegelGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RettOgOmsorg;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.SamtidigUttaksprosent;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknad;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknadstype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.GraderingIkkeInnvilgetÅrsak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.InnvilgetÅrsak;
@@ -730,7 +752,7 @@ class ForeldrepengerDelregelTest {
     void bfhr_rundt_fødsel_men_før_fødsel_blir_avslått() {
         var fødselsdato = LocalDate.of(2022, 10, 1);
 
-        var oppgittPeriode = oppgittPeriode(fødselsdato.minusDays(2), fødselsdato.plusWeeks(1).plusDays(1));
+        var oppgittPeriode = oppgittPeriode(fødselsdato.minusDays(2), fødselsdato.minusDays(1));
         var grunnlag = grunnlagFar(fødselsdato)
                 .behandling(new Behandling.Builder().søkerErMor(false).kreverSammenhengendeUttak(false))
                 .søknad(søknad(oppgittPeriode))

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/OrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/OrkestreringTest.java
@@ -20,10 +20,45 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.*;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.regler.SøknadsfristUtil;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktivitetIdentifikator;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktørId;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AnnenPart;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AnnenpartUttakPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AnnenpartUttakPeriodeAktivitet;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeid;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Arbeidsforhold;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Behandling;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Datoer;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Dokumentasjon;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.EndringAvStilling;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriodeAktivitet;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.GyldigGrunnPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Konto;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Kontoer;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppholdÅrsak;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Opptjening;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Orgnummer;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedAvklartMorsAktivitet;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedInnleggelse;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeUtenOmsorg;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeVurderingType;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RegelGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RettOgOmsorg;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Revurdering;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.SamtidigUttaksprosent;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknad;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknadstype;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Utbetalingsgrad;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.UtsettelseÅrsak;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.UttakPeriode;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Vedtak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.Manuellbehandlingårsak;
 import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
@@ -1066,18 +1101,16 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
 
         var resultat = fastsettPerioder(grunnlag);
 
-        assertThat(resultat).hasSize(8);
-        assertThat(resultat.get(0).getUttakPeriode().getPerioderesultattype()).isEqualTo(INNVILGET); // Fødsel P1
+        assertThat(resultat).hasSize(6);
+        assertThat(resultat.get(0).getUttakPeriode().getPerioderesultattype()).isEqualTo(INNVILGET); // Før fødsel P1
         assertThat(resultat.get(0).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(new Trekkdager(3));
-        assertThat(resultat.get(1).getUttakPeriode().getPerioderesultattype()).isEqualTo(INNVILGET); // Fødsel P2
-        assertThat(resultat.get(1).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(new Trekkdager(7));
-        assertThat(resultat.get(2).getUttakPeriode().getPerioderesultattype()).isEqualTo(MANUELL_BEHANDLING); // Brukt opp 10 dager ifm fødsel
-        assertThat(resultat.get(3).getUttakPeriode().getPerioderesultattype()).isEqualTo(MANUELL_BEHANDLING); // Søker inn i første 6 uker
-        assertThat(resultat.get(4).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT); // MSP
-        assertThat(resultat.get(5).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN); // MSP tom på konto
-        assertThat(resultat.get(6).getUttakPeriode().getPerioderesultattype()).isEqualTo(INNVILGET); // Minsterett
-        assertThat(resultat.get(6).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(new Trekkdager(30)); // Minsterett
-        assertThat(resultat.get(7).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN); // Oppbrukt minsterett
+        assertThat(resultat.get(1).getUttakPeriode().getPerioderesultattype()).isEqualTo(INNVILGET); // Etter Fødsel P2
+        assertThat(resultat.get(1).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(new Trekkdager(15));
+        assertThat(resultat.get(2).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT); // MSP
+        assertThat(resultat.get(3).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN); // MSP tom på konto
+        assertThat(resultat.get(4).getUttakPeriode().getPerioderesultattype()).isEqualTo(INNVILGET); // Minsterett
+        assertThat(resultat.get(4).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(new Trekkdager(22)); // Minsterett
+        assertThat(resultat.get(5).getUttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN); // Oppbrukt minsterett
     }
 
 }

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/TapendeSakOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/TapendeSakOrkestreringTest.java
@@ -317,7 +317,7 @@ class TapendeSakOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
 
         var resultat = fastsettPerioder(grunnlag);
 
-        assertThat(resultat).hasSize(3);
+        assertThat(resultat).hasSize(5);
         assertThat(resultat.stream().map(FastsettePeriodeResultat::getUttakPeriode).map(UttakPeriode::getPerioderesultattype).allMatch(INNVILGET::equals)).isTrue();
     }
 


### PR DESCRIPTION
Endrer regler for delflyt foreldrepenger - bare far/medmor rett, ikke aleneomsorg
Knekkpunktidentifisering - lager bare knekkpunkt for første 6 uker dersom kvoter eller gamle regler