### PR TITLE
NOJIRA forenklet sjekk negativ saldo

### DIFF
--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/saldo/SaldoUtregningTest.java
@@ -1381,6 +1381,7 @@ class SaldoUtregningTest {
                 farUttakRundtFødselPeriode, farUttakRundtFødselDager);
     }
 
+    // TODO (jol): slett eller bruk ifm bortfalt/avkortet minsterett
     private SaldoUtregning lagForenkletAvkortetSaldoUtregning(Set<Stønadskonto> stønadskontoer, // NOSONAR
                                                               List<FastsattUttakPeriode> søkersPerioder,
                                                               Trekkdager minsterettDager,


### PR DESCRIPTION
Legger til en forenklet sjekk for negativSaldoForNoenKonto - som ikke sjekker frigjorte dager.
Denne er tenkt brukt ifm berørt behandling der man kun trenger vite om tilfellet for å velge en tidlig nok endringsdato - uten å håndtere kompleksitet involvert med tapende perioder og frigjøring. Vil treffe noen flere tilfelle - men oppnår ønsket effekt