### PR TITLE
TFP-4969 automatiser avslag ved oppbrukt uten aktivitetskrav

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmUkjentErFellesEllerDokumentert.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmUkjentErFellesEllerDokumentert.java
@@ -1,0 +1,29 @@
+package no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav;
+
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorErIAktivitet.periodeMedAktivitet;
+
+import java.util.Objects;
+
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedAvklartMorsAktivitet;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+
+@RuleDocumentation(SjekkOmUkjentErFellesEllerDokumentert.ID)
+public class SjekkOmUkjentErFellesEllerDokumentert extends LeafSpecification<FastsettePeriodeGrunnlag> {
+    public static final String ID = "AVSLAG_AKT_13";
+    public static final String BESKRIVELSE = "Er ikke angitt aktivitet vurdert som aktiv eller dokumentert?";
+
+    public SjekkOmUkjentErFellesEllerDokumentert() {
+        super(ID);
+    }
+
+    @Override
+    public Evaluation evaluate(FastsettePeriodeGrunnlag fastsettePeriodeGrunnlag) {
+        var periodeMedAktivitet = periodeMedAktivitet(fastsettePeriodeGrunnlag);
+        return Objects.equals(fastsettePeriodeGrunnlag.getAktuellPeriode().getStønadskontotype(), Stønadskontotype.FELLESPERIODE) ||
+                periodeMedAktivitet.filter(PeriodeMedAvklartMorsAktivitet::erDokumentert).isPresent() ? ja() : nei();
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/IkkeOppfyltÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/IkkeOppfyltÅrsak.java
@@ -23,6 +23,7 @@ public enum IkkeOppfyltÅrsak implements PeriodeResultatÅrsak {
     MOR_IKKE_RETT_FP(4075, "Ikke rett til fellesperiode fordi mor ikke har rett til foreldrepenger"),
     UTTAK_ETTER_NY_STØNADSPERIODE(4104, "Uttak etter start av ny stønadsperiode"),
     FAR_PERIODE_FØR_FØDSEL(4105, "Far/medmor søker uttak før fødsel/omsorg"),
+    AKTIVITET_UKJENT_UDOKUMENTERT(4107, "Aktivitetskravet ikke oppgitt eller ikke dokumentert"),
 
     // Adopsjon
     FØR_OMSORGSOVERTAKELSE(4100, "Uttak før omsorgsovertakelse"),

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/MinsterettOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/MinsterettOrkestreringTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
 
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedAvklartMorsAktivitet.Resultat.I_AKTIVITET;
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak.AKTIVITET_UKJENT_UDOKUMENTERT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.InnvilgetÅrsak.FORELDREPENGER_KUN_FAR_HAR_RETT;
@@ -56,7 +57,7 @@ class MinsterettOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
         var fastsattePerioder = fastsettPerioder(grunnlag);
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 40))).isTrue();
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 35))).isTrue();
-        assertThat(fastsattePerioder.stream().anyMatch(p -> harManuellPeriode(p.getUttakPeriode(), Manuellbehandlingårsak.MOR_UFØR, 20))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, AKTIVITET_UKJENT_UDOKUMENTERT, 20))).isTrue();; // Søkt ufør, ikke dager igjen på minstekvote
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, BARE_FAR_RETT_IKKE_SØKT, 5))).isTrue();
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, IKKE_STØNADSDAGER_IGJEN, -1))).isTrue();
     }
@@ -100,7 +101,7 @@ class MinsterettOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
         var fastsattePerioder = fastsettPerioder(grunnlag);
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 75))).isTrue();
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, BARE_FAR_RETT_IKKE_SØKT, 5))).isTrue();
-        assertThat(fastsattePerioder.stream().anyMatch(p -> harManuellPeriode(p.getUttakPeriode(), Manuellbehandlingårsak.MOR_UFØR, 5))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, AKTIVITET_UKJENT_UDOKUMENTERT, 5))).isTrue();; // Søkt ufør, ikke dager igjen på minstekvote
     }
 
     @Test
@@ -147,7 +148,7 @@ class MinsterettOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
         var fastsattePerioder = fastsettPerioder(grunnlag);
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 40))).isTrue();
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 35))).isTrue();
-        assertThat(fastsattePerioder.stream().anyMatch(p -> harManuellPeriode(p.getUttakPeriode(), Manuellbehandlingårsak.MOR_UFØR, 5))).isTrue(); // Søkt ufør, ikke dager igjen på minstekvote
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, AKTIVITET_UKJENT_UDOKUMENTERT, 5))).isTrue();; // Søkt ufør, ikke dager igjen på minstekvote
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, BARE_FAR_RETT_IKKE_SØKT, 5))).isTrue();
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, IKKE_STØNADSDAGER_IGJEN, -1))).isTrue();
     }
@@ -216,7 +217,7 @@ class MinsterettOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
         var fastsattePerioder = fastsettPerioder(grunnlag);
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.INNVILGET, FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR, 75))).isTrue();
         assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, BARE_FAR_RETT_IKKE_SØKT, 5))).isTrue();
-        assertThat(fastsattePerioder.stream().anyMatch(p -> harManuellPeriode(p.getUttakPeriode(), Manuellbehandlingårsak.MOR_UFØR, 5))).isTrue();
+        assertThat(fastsattePerioder.stream().anyMatch(p -> harPeriode(p.getUttakPeriode(), Perioderesultattype.AVSLÅTT, AKTIVITET_UKJENT_UDOKUMENTERT, 5))).isTrue();; // Søkt ufør, ikke dager igjen på minstekvote
     }
 
     private boolean harPeriode(UttakPeriode p, Perioderesultattype prt, PeriodeResultatÅrsak prå, int dager) {


### PR DESCRIPTION
Implementer oppdatert gliphy-flyt
* Ukjent aktivitet og konto <> FELLESPERIODE og ikke avklart dokumentert -> avslå 4107 dager u/aktivitet oppbrukt
* oppgitt og bekreftet uføre -> avslå 4107 dager u/aktivitet oppbrukt

Vil omfatte avrundingsproblem/gradering i søknad + fri utsettelse uten angitt mors aktivitet
Vil også ta perioder med mors aktivitet = IKKE_OPPGITT - den sendes inn som aktivitet = null