### PR TITLE
TFP-4969 oppdatert avslag aktivitetskrav mhp rekkefølge av sjekker

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/AvslagAktivitetskravDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/AvslagAktivitetskravDelregel.java
@@ -29,7 +29,7 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.S
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorSyk;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorUtdanning;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorsAktivitetErKjent;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmUkjentErFellesEllerDokumentert;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmUkjentErFellesEllerAvklart;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.FastsettePeriodeUtfall;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfylt;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak;
@@ -57,14 +57,8 @@ public class AvslagAktivitetskravDelregel implements RuleService<FastsettePeriod
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmKjentAktivitet() {
         return rs.hvisRegel(SjekkOmMorsAktivitetErKjent.ID, SjekkOmMorsAktivitetErKjent.BESKRIVELSE)
-                .hvis(new SjekkOmMorsAktivitetErKjent(), sjekkOmMorOppgittUføretrygd())
+                .hvis(new SjekkOmMorsAktivitetErKjent(), sjekkOmMorArbeid())
                 .ellers(sjekkOmUkjentAktivitetVurdert());
-    }
-
-    private Specification<FastsettePeriodeGrunnlag> sjekkOmMorOppgittUføretrygd() {
-        return rs.hvisRegel(SjekkOmMorOppgittUføre.ID, SjekkOmMorOppgittUføre.BESKRIVELSE)
-                .hvis(new SjekkOmMorOppgittUføre(), sjekkOmMorBekreftetUføretrygd())
-                .ellers(sjekkOmMorArbeid());
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmMorArbeid() {
@@ -106,6 +100,12 @@ public class AvslagAktivitetskravDelregel implements RuleService<FastsettePeriod
     private Specification<FastsettePeriodeGrunnlag> sjekkOmMorKombinasjonArbeidUtdanning() {
         return rs.hvisRegel(SjekkOmMorKombinasjonArbeidUtdanning.ID, SjekkOmMorKombinasjonArbeidUtdanning.BESKRIVELSE)
                 .hvis(new SjekkOmMorKombinasjonArbeidUtdanning(), morKombinasjonArbeidUtdanning())
+                .ellers(sjekkOmMorOppgittUføretrygd());
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmMorOppgittUføretrygd() {
+        return rs.hvisRegel(SjekkOmMorOppgittUføre.ID, SjekkOmMorOppgittUføre.BESKRIVELSE)
+                .hvis(new SjekkOmMorOppgittUføre(), sjekkOmMorBekreftetUføretrygd())
                 .ellers(utfall1314AvklarAktivitetSituasjon());
     }
 
@@ -116,8 +116,8 @@ public class AvslagAktivitetskravDelregel implements RuleService<FastsettePeriod
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUkjentAktivitetVurdert() {
-        return rs.hvisRegel(SjekkOmUkjentErFellesEllerDokumentert.ID, SjekkOmUkjentErFellesEllerDokumentert.BESKRIVELSE)
-                .hvis(new SjekkOmUkjentErFellesEllerDokumentert(), Manuellbehandling.opprett("UT1315", null,
+        return rs.hvisRegel(SjekkOmUkjentErFellesEllerAvklart.ID, SjekkOmUkjentErFellesEllerAvklart.BESKRIVELSE)
+                .hvis(new SjekkOmUkjentErFellesEllerAvklart(), Manuellbehandling.opprett("UT1315", null,
                         Manuellbehandlingårsak.AKTIVITEKTSKRAVET_MÅ_SJEKKES_MANUELT, true, false))
                 .ellers(avslå("UT1323", AKTIVITET_UKJENT_UDOKUMENTERT));
     }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmUkjentErFellesEllerAvklart.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmUkjentErFellesEllerAvklart.java
@@ -5,18 +5,17 @@ import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.ak
 import java.util.Objects;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunnlag;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedAvklartMorsAktivitet;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
 
-@RuleDocumentation(SjekkOmUkjentErFellesEllerDokumentert.ID)
-public class SjekkOmUkjentErFellesEllerDokumentert extends LeafSpecification<FastsettePeriodeGrunnlag> {
+@RuleDocumentation(SjekkOmUkjentErFellesEllerAvklart.ID)
+public class SjekkOmUkjentErFellesEllerAvklart extends LeafSpecification<FastsettePeriodeGrunnlag> {
     public static final String ID = "AVSLAG_AKT_13";
-    public static final String BESKRIVELSE = "Er ikke angitt aktivitet vurdert som aktiv eller dokumentert?";
+    public static final String BESKRIVELSE = "Er ikke angitt aktivitet vurdert mhp aktivitet?";
 
-    public SjekkOmUkjentErFellesEllerDokumentert() {
+    public SjekkOmUkjentErFellesEllerAvklart() {
         super(ID);
     }
 
@@ -24,6 +23,6 @@ public class SjekkOmUkjentErFellesEllerDokumentert extends LeafSpecification<Fas
     public Evaluation evaluate(FastsettePeriodeGrunnlag fastsettePeriodeGrunnlag) {
         var periodeMedAktivitet = periodeMedAktivitet(fastsettePeriodeGrunnlag);
         return Objects.equals(fastsettePeriodeGrunnlag.getAktuellPeriode().getStønadskontotype(), Stønadskontotype.FELLESPERIODE) ||
-                periodeMedAktivitet.filter(PeriodeMedAvklartMorsAktivitet::erDokumentert).isPresent() ? ja() : nei();
+                periodeMedAktivitet.isPresent() ? ja() : nei();
     }
 }


### PR DESCRIPTION
Oppdatert gliphy og flyt - må sjekke på oppgitt uføre etter alle sjekkene på aktivitet - ellers flyr ikke BFHR / UFøre-tilfellet