### PR TITLE
TFP-5099 avslå tekniske fri utsettelse u/aktivitet som MSP

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/AvslagAktivitetskravDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/AvslagAktivitetskravDelregel.java
@@ -15,10 +15,12 @@ import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOpp
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak.AKTIVITETSKRAVET_UTDANNING_IKKE_DOKUMENTERT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak.AKTIVITETSKRAVET_UTDANNING_IKKE_OPPFYLT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak.AKTIVITET_UKJENT_UDOKUMENTERT;
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak.BARE_FAR_RETT_IKKE_SØKT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak.FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_IKKE_UFØR;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmTomForAlleSineKontoer;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmAktivitetErDokumentert;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmFriUtsettelse;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorArbeid;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorBekreftetUføre;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorInnlagt;
@@ -29,7 +31,7 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.S
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorSyk;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorUtdanning;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorsAktivitetErKjent;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmErUttakUtenAktivitetskrav;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmUttakOgUtenAktivitetskrav;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.FastsettePeriodeUtfall;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfylt;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfyltÅrsak;
@@ -116,14 +118,21 @@ public class AvslagAktivitetskravDelregel implements RuleService<FastsettePeriod
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmMorBekreftetUføretrygdErUttak() {
-        return rs.hvisRegel(SjekkOmErUttakUtenAktivitetskrav.ID, SjekkOmErUttakUtenAktivitetskrav.BESKRIVELSE)
-                .hvis(new SjekkOmErUttakUtenAktivitetskrav(), avslå("UT1324", AKTIVITET_UKJENT_UDOKUMENTERT))
+        return rs.hvisRegel(SjekkOmUttakOgUtenAktivitetskrav.ID, SjekkOmUttakOgUtenAktivitetskrav.BESKRIVELSE)
+                .hvis(new SjekkOmUttakOgUtenAktivitetskrav(), avslå("UT1324", AKTIVITET_UKJENT_UDOKUMENTERT))
                 .ellers(utfall1314AvklarAktivitetSituasjon());
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmUkjentAktivitetErUttakUtenAktivitetskrav() {
-        return rs.hvisRegel(SjekkOmErUttakUtenAktivitetskrav.ID, SjekkOmErUttakUtenAktivitetskrav.BESKRIVELSE)
-                .hvis(new SjekkOmErUttakUtenAktivitetskrav(), avslå("UT1323", AKTIVITET_UKJENT_UDOKUMENTERT))
+        return rs.hvisRegel(SjekkOmUttakOgUtenAktivitetskrav.ID, SjekkOmUttakOgUtenAktivitetskrav.BESKRIVELSE)
+                .hvis(new SjekkOmUttakOgUtenAktivitetskrav(), avslå("UT1323", AKTIVITET_UKJENT_UDOKUMENTERT))
+                .ellers(sjekkOmUkjentAktivitetErFriUtsettelse());
+    }
+
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmUkjentAktivitetErFriUtsettelse() {
+        // Pga praksis med tekniske perioder u/aktivitet fra søknader fram til første uttak.
+        return rs.hvisRegel(SjekkOmFriUtsettelse.ID, SjekkOmFriUtsettelse.BESKRIVELSE)
+                .hvis(new SjekkOmFriUtsettelse(), avslå("UT1325", BARE_FAR_RETT_IKKE_SØKT))
                 .ellers(Manuellbehandling.opprett("UT1315", null,
                         Manuellbehandlingårsak.AKTIVITEKTSKRAVET_MÅ_SJEKKES_MANUELT, true, false));
     }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmFriUtsettelse.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmFriUtsettelse.java
@@ -1,0 +1,24 @@
+package no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav;
+
+import java.util.Objects;
+
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunnlag;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.UtsettelseÅrsak;
+import no.nav.fpsak.nare.doc.RuleDocumentation;
+import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.LeafSpecification;
+
+@RuleDocumentation(SjekkOmFriUtsettelse.ID)
+public class SjekkOmFriUtsettelse extends LeafSpecification<FastsettePeriodeGrunnlag> {
+    public static final String ID = "AVSLAG_AKT_14";
+    public static final String BESKRIVELSE = "Er perioden utsettelse med årsak Fri?";
+
+    public SjekkOmFriUtsettelse() {
+        super(ID);
+    }
+
+    @Override
+    public Evaluation evaluate(FastsettePeriodeGrunnlag fastsettePeriodeGrunnlag) {
+        return Objects.equals(UtsettelseÅrsak.FRI, fastsettePeriodeGrunnlag.getAktuellPeriode().getUtsettelseÅrsak()) ? ja() : nei();
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmUttakOgUtenAktivitetskrav.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/betingelser/aktkrav/SjekkOmUttakOgUtenAktivitetskrav.java
@@ -5,12 +5,12 @@ import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
 
-@RuleDocumentation(SjekkOmErUttakUtenAktivitetskrav.ID)
-public class SjekkOmErUttakUtenAktivitetskrav extends LeafSpecification<FastsettePeriodeGrunnlag> {
+@RuleDocumentation(SjekkOmUttakOgUtenAktivitetskrav.ID)
+public class SjekkOmUttakOgUtenAktivitetskrav extends LeafSpecification<FastsettePeriodeGrunnlag> {
     public static final String ID = "AVSLAG_AKT_13";
-    public static final String BESKRIVELSE = "Er ikke angitt aktivitet vurdert mhp aktivitet?";
+    public static final String BESKRIVELSE = "Er perioden uttak og finnes dager uten aktivitetskrav?";
 
-    public SjekkOmErUttakUtenAktivitetskrav() {
+    public SjekkOmUttakOgUtenAktivitetskrav() {
         super(ID);
     }
 


### PR DESCRIPTION
Ny AVSLAG_AKT_14 som følger dersom AKT_13 sier nei: Avslå FRI u/aktivitet som MSP. Matcher eksternt budskap