### PR TITLE
Fritt uttak skal ikke ta hensyn til oppholdsperioder

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePerioderRegelOrkestrering.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePerioderRegelOrkestrering.java
@@ -40,6 +40,7 @@ public class FastsettePerioderRegelOrkestrering {
         var allePerioderSomSkalFastsettes = samletUttaksperioder(grunnlag, orkestreringTillegg).stream()
                 .filter(periode -> !erHelg(periode))
                 .filter(periode -> !oppholdSomFyllesAvAnnenpart(periode, annenpartUttaksperioder(grunnlag)))
+                .filter(periode -> grunnlag.getBehandling().isKreverSammenhengendeUttak() || !periode.isOpphold())
                 .map(periode -> oppdaterMedAktiviteter(periode, grunnlag.getArbeid()))
                 .collect(Collectors.toList());
         validerOverlapp(map(allePerioderSomSkalFastsettes));

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/AnnenpartUttakPeriode.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/AnnenpartUttakPeriode.java
@@ -16,7 +16,6 @@ public class AnnenpartUttakPeriode extends LukketPeriode {
     private boolean samtidigUttak;
     private boolean flerbarnsdager;
     private boolean utsettelse;
-    private boolean oppholdsperiode;
     private OppholdÅrsak oppholdÅrsak;
     private boolean innvilget;
     private LocalDate senestMottattDato;
@@ -46,7 +45,7 @@ public class AnnenpartUttakPeriode extends LukketPeriode {
     }
 
     public boolean isOppholdsperiode() {
-        return oppholdsperiode;
+        return getOppholdÅrsak() != null;
     }
 
     public OppholdÅrsak getOppholdÅrsak() {
@@ -60,7 +59,6 @@ public class AnnenpartUttakPeriode extends LukketPeriode {
                 .samtidigUttak(this.samtidigUttak)
                 .flerbarnsdager(this.flerbarnsdager)
                 .utsettelse(this.innvilget)
-                .oppholdsperiode(this.oppholdsperiode)
                 .innvilget(this.innvilget)
                 .oppholdsårsak(this.oppholdÅrsak)
                 .uttakPeriodeAktiviteter(annenpartUttakPeriodeAktiviteter)
@@ -90,13 +88,13 @@ public class AnnenpartUttakPeriode extends LukketPeriode {
             return false;
         var that = (AnnenpartUttakPeriode) o;
         return samtidigUttak == that.samtidigUttak && flerbarnsdager == that.flerbarnsdager && utsettelse == that.utsettelse
-                && oppholdsperiode == that.oppholdsperiode && innvilget == that.innvilget && Objects.equals(aktiviteter,
-                that.aktiviteter) && oppholdÅrsak == that.oppholdÅrsak && Objects.equals(senestMottattDato, that.senestMottattDato);
+                && innvilget == that.innvilget && Objects.equals(aktiviteter, that.aktiviteter) && oppholdÅrsak == that.oppholdÅrsak
+            && Objects.equals(senestMottattDato, that.senestMottattDato);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), aktiviteter, samtidigUttak, flerbarnsdager, utsettelse, oppholdsperiode, oppholdÅrsak,
+        return Objects.hash(super.hashCode(), aktiviteter, samtidigUttak, flerbarnsdager, utsettelse, oppholdÅrsak,
                 innvilget, senestMottattDato);
     }
 
@@ -108,7 +106,7 @@ public class AnnenpartUttakPeriode extends LukketPeriode {
         }
 
         public static Builder opphold(LocalDate fom, LocalDate tom, OppholdÅrsak oppholdÅrsak) {
-            return new Builder(fom, tom).oppholdsperiode(true).oppholdsårsak(oppholdÅrsak);
+            return new Builder(fom, tom).oppholdsårsak(oppholdÅrsak);
         }
 
         public static Builder uttak(LocalDate fom, LocalDate tom) {
@@ -137,11 +135,6 @@ public class AnnenpartUttakPeriode extends LukketPeriode {
 
         private Builder utsettelse(boolean utsettelse) {
             kladd.utsettelse = utsettelse;
-            return this;
-        }
-
-        private Builder oppholdsperiode(boolean oppholdsperiode) {
-            kladd.oppholdsperiode = oppholdsperiode;
             return this;
         }
 

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/OrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/OrkestreringTest.java
@@ -4,6 +4,8 @@ import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.RegelGrunnlagT
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.RegelGrunnlagTestBuilder.ARBEIDSFORHOLD_2;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.DokumentasjonVurdering.INNLEGGELSE_SØKER_DOKUMENTERT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.DokumentasjonVurdering.MORS_AKTIVITET_DOKUMENTERT_AKTIVITET;
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode.forOpphold;
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode.forVanligPeriode;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.AVSLÅTT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.INNVILGET;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.MANUELL_BEHANDLING;
@@ -40,7 +42,6 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUtta
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriodeAktivitet;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Konto;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Kontoer;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppholdÅrsak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Opptjening;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Orgnummer;
@@ -122,9 +123,9 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
         var fødselsdato = LocalDate.of(2017, 11, 1);
         var sisteUttaksdag = fødselsdato.plusWeeks(6).minusDays(1);
         var søknadsfrist = sisteUttaksdag.plusMonths(3).with(TemporalAdjusters.lastDayOfMonth());
-        var fpff = OppgittPeriode.forVanligPeriode(FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1),
+        var fpff = forVanligPeriode(FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1),
                 null, false, søknadsfrist.plusWeeks(1), søknadsfrist.plusWeeks(1), null, null);
-        var mødrekvote = OppgittPeriode.forVanligPeriode(MØDREKVOTE, fødselsdato, sisteUttaksdag, null, false,
+        var mødrekvote = forVanligPeriode(MØDREKVOTE, fødselsdato, sisteUttaksdag, null, false,
                 søknadsfrist.plusWeeks(1), søknadsfrist.plusWeeks(1), null, null);
         var grunnlag = basicGrunnlagMor(fødselsdato)
                 .rettOgOmsorg(new RettOgOmsorg.Builder().samtykke(true))
@@ -164,10 +165,10 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
     void skalKnekkePeriodenVedGrenseForSøknadsfrist() {
         var fødselsdato = LocalDate.of(2017, 11, 1);
         var mottattDato = fødselsdato.plusMonths(4).plusWeeks(1);
-        var fpff = OppgittPeriode.forVanligPeriode(FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1),
+        var fpff = forVanligPeriode(FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1),
                 null, false, mottattDato, mottattDato, null, null);
         //Mødrekvote skal knekkes på for at første delen skal avlås pga søknadsfrist
-        var mødrekvote = OppgittPeriode.forVanligPeriode(MØDREKVOTE, fødselsdato, fødselsdato.plusWeeks(6).minusDays(1), null, false,
+        var mødrekvote = forVanligPeriode(MØDREKVOTE, fødselsdato, fødselsdato.plusWeeks(6).minusDays(1), null, false,
                 mottattDato, mottattDato, null, null);
         var grunnlag = basicGrunnlagMor(fødselsdato)
                 .søknad(søknad(Søknadstype.FØDSEL, fpff, mødrekvote));
@@ -331,7 +332,7 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
         var periodeFom = fødselsdato.plusYears(1);
         var periodeTom = periodeFom.plusDays(20);
         var kontoer = new Kontoer.Builder().konto(konto(FEDREKVOTE, 15));
-        var fedrekvote = OppgittPeriode.forVanligPeriode(FEDREKVOTE, periodeFom, periodeTom, null, false,
+        var fedrekvote = forVanligPeriode(FEDREKVOTE, periodeFom, periodeTom, null, false,
                 periodeTom.plusYears(2), periodeTom.plusYears(2), null, null);
         var grunnlag = RegelGrunnlagTestBuilder.create()
                 .datoer(datoer(fødselsdato))
@@ -663,13 +664,13 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD_1)))
                 .kontoer(kontoer)
                 .datoer(datoer(fødselsdato))
-                .behandling(morBehandling())
+                .behandling(morBehandling().kreverSammenhengendeUttak(true))
                 .rettOgOmsorg(beggeRett())
                 .søknad(new Søknad.Builder().oppgittPeriode(
                         oppgittPeriode(FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1)))
                         .oppgittPeriode(oppgittPeriode(MØDREKVOTE, fødselsdato, fødselsdato.plusWeeks(6).minusDays(1)))
                         //Går tom for fedrekvote i oppholdsperioden
-                        .oppgittPeriode(OppgittPeriode.forOpphold(fødselsdato.plusWeeks(6), fødselsdato.plusWeeks(8),
+                        .oppgittPeriode(forOpphold(fødselsdato.plusWeeks(6), fødselsdato.plusWeeks(8),
                                 OppholdÅrsak.FEDREKVOTE_ANNEN_FORELDER, null, null)));
 
         var resultat = fastsettPerioder(grunnlag);
@@ -868,11 +869,11 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
     @Test
     void innvilge_foreldrepenger_14_uker_før_fødsel_men_ikke_12_uker_før_termin_ved_terminsøknad() {
         var termin = LocalDate.of(2020, 6, 10);
-        var fp = OppgittPeriode.forVanligPeriode(FORELDREPENGER, termin.minusWeeks(15), termin.minusWeeks(3).minusDays(1), null, false,
+        var fp = forVanligPeriode(FORELDREPENGER, termin.minusWeeks(15), termin.minusWeeks(3).minusDays(1), null, false,
                 null, null, null, null);
-        var fpff = OppgittPeriode.forVanligPeriode(FORELDREPENGER_FØR_FØDSEL, termin.minusWeeks(3), termin.minusDays(1), null, false,
+        var fpff = forVanligPeriode(FORELDREPENGER_FØR_FØDSEL, termin.minusWeeks(3), termin.minusDays(1), null, false,
                 null, null, null, null);
-        var fp2 = OppgittPeriode.forVanligPeriode(FORELDREPENGER, termin, termin.plusWeeks(4), null, false,
+        var fp2 = forVanligPeriode(FORELDREPENGER, termin, termin.plusWeeks(4), null, false,
                 null, null, null, null);
         var testGrunnlag = basicGrunnlag()
                 .datoer(new Datoer.Builder().termin(termin).fødsel(termin.plusWeeks(2)))
@@ -1086,11 +1087,11 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
                         .farUttakRundtFødselDager(10))
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD_1)))
                 .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
-                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FORELDREPENGER, termindato.minusDays(2), fødselsdato.plusWeeks(2).minusDays(1),
+                        .oppgittPeriode(forVanligPeriode(FORELDREPENGER, termindato.minusDays(2), fødselsdato.plusWeeks(2).minusDays(1),
                                 null, false, fødselsdato, fødselsdato, null, null))
-                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(2), fødselsdato.plusWeeks(3).minusDays(1),
+                        .oppgittPeriode(forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(2), fødselsdato.plusWeeks(3).minusDays(1),
                                 null, false, fødselsdato, fødselsdato, null, null))
-                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(50), fødselsdato.plusWeeks(58).minusDays(1),
+                        .oppgittPeriode(forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(50), fødselsdato.plusWeeks(58).minusDays(1),
                                 null, false, fødselsdato, fødselsdato, null, null))
                 );
 
@@ -1125,11 +1126,11 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
                         .farUttakRundtFødselDager(10))
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD_1)))
                 .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
-                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(2), fødselsdato.plusWeeks(4).minusDays(1),
+                        .oppgittPeriode(forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(2), fødselsdato.plusWeeks(4).minusDays(1),
                                 null, false, fødselsdato, fødselsdato, null, null))
-                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(15), fødselsdato.plusWeeks(17).minusDays(1),
+                        .oppgittPeriode(forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(15), fødselsdato.plusWeeks(17).minusDays(1),
                                 null, false, fødselsdato, fødselsdato, null, null))
-                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(25), fødselsdato.plusWeeks(29).minusDays(1),
+                        .oppgittPeriode(forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(25), fødselsdato.plusWeeks(29).minusDays(1),
                                 null, false, fødselsdato, fødselsdato, null, null))
                 );
 
@@ -1164,9 +1165,9 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
                         .farUttakRundtFødselDager(10))
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD_1)))
                 .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
-                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(15), fødselsdato.plusWeeks(24).minusDays(1),
+                        .oppgittPeriode(forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(15), fødselsdato.plusWeeks(24).minusDays(1),
                                 null, false, fødselsdato, fødselsdato, null, null))
-                        .oppgittPeriode(OppgittPeriode.forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(40), fødselsdato.plusWeeks(43).minusDays(1),
+                        .oppgittPeriode(forVanligPeriode(FORELDREPENGER, fødselsdato.plusWeeks(40), fødselsdato.plusWeeks(43).minusDays(1),
                                 null, false, fødselsdato, fødselsdato, null, null))
                 );
 
@@ -1183,6 +1184,23 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
         assertThat(resultat.get(3).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(new Trekkdager(5));
         assertThat(resultat.get(4).getUttakPeriode().getPerioderesultattype()).isEqualTo(AVSLÅTT);
         assertThat(resultat.get(4).getUttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(Trekkdager.ZERO);
+    }
+
+    @Test
+    void oppholdsperioder_med_fritt_uttak_skal_fjernes() {
+        var fødselsdato = LocalDate.of(2022, 11, 4);
+        var grunnlag = basicGrunnlagMor(fødselsdato)
+            .søknad(søknad(Søknadstype.FØDSEL,
+                oppgittPeriode(FORELDREPENGER_FØR_FØDSEL, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1)),
+                oppgittPeriode(MØDREKVOTE, fødselsdato, fødselsdato.plusWeeks(6).minusDays(1)),
+                forOpphold(fødselsdato.plusWeeks(6), fødselsdato.plusWeeks(7).minusDays(1), OppholdÅrsak.FEDREKVOTE_ANNEN_FORELDER, fødselsdato, fødselsdato),
+                oppgittPeriode(FELLESPERIODE, fødselsdato.plusWeeks(7), fødselsdato.plusWeeks(10).minusDays(1))
+                ));
+
+        var resultat = fastsettPerioder(grunnlag);
+
+        assertThat(resultat).hasSize(3);
+        assertThat(resultat.get(2).getUttakPeriode().getStønadskontotype()).isEqualTo(FELLESPERIODE);
     }
 
 }

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/SaldoUtregningTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/SaldoUtregningTjenesteTest.java
@@ -8,6 +8,7 @@ import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Aktiv
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode.ResultatÅrsak.ANNET;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode.ResultatÅrsak.INNVILGET_FORELDREPENGER_KUN_FAR_HAR_RETT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppholdÅrsak.FEDREKVOTE_ANNEN_FORELDER;
+import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppholdÅrsak.FELLESPERIODE_ANNEN_FORELDER;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.AVSLÅTT;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype.INNVILGET;
 import static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype.FEDREKVOTE;
@@ -96,7 +97,7 @@ class SaldoUtregningTjenesteTest {
                         new AnnenPart.Builder().uttaksperiode(annenpartOpphold).uttaksperiode(annenpartUttaksperiode))
                 .kontoer(kontoer)
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(annenAktivitet())))
-                .behandling(new Behandling.Builder().berørtBehandling(true))
+                .behandling(new Behandling.Builder().berørtBehandling(true).kreverSammenhengendeUttak(true))
                 .søknad(new Søknad.Builder().oppgittPeriode(aktuellPeriode))
                 .build();
 
@@ -124,7 +125,7 @@ class SaldoUtregningTjenesteTest {
                         new AnnenPart.Builder().uttaksperiode(annenpartOpphold).uttaksperiode(annenpartUttaksperiode))
                 .kontoer(kontoer)
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(annenAktivitet())))
-                .behandling(new Behandling.Builder().berørtBehandling(true))
+                .behandling(new Behandling.Builder().berørtBehandling(true).kreverSammenhengendeUttak(true))
                 .søknad(new Søknad.Builder().oppgittPeriode(aktuellPeriode))
                 .build();
 
@@ -152,7 +153,7 @@ class SaldoUtregningTjenesteTest {
                         new AnnenPart.Builder().uttaksperiode(annenpartOpphold).uttaksperiode(annenpartUttaksperiode))
                 .kontoer(kontoer)
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(annenAktivitet())))
-                .behandling(new Behandling.Builder().berørtBehandling(true))
+                .behandling(new Behandling.Builder().berørtBehandling(true).kreverSammenhengendeUttak(true))
                 .søknad(new Søknad.Builder().oppgittPeriode(aktuellPeriode))
                 .build();
 
@@ -180,7 +181,7 @@ class SaldoUtregningTjenesteTest {
                         new AnnenPart.Builder().uttaksperiode(annenpartOpphold).uttaksperiode(annenpartUttaksperiode))
                 .kontoer(kontoer)
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(annenAktivitet())))
-                .behandling(new Behandling.Builder().berørtBehandling(true))
+                .behandling(new Behandling.Builder().berørtBehandling(true).kreverSammenhengendeUttak(true))
                 .søknad(new Søknad.Builder().oppgittPeriode(aktuellPeriode))
                 .build();
 
@@ -403,7 +404,7 @@ class SaldoUtregningTjenesteTest {
                         new AnnenpartUttakPeriodeAktivitet(forSelvstendigNæringsdrivende(), FELLESPERIODE, new Trekkdager(5), Utbetalingsgrad.HUNDRED)))
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(fastsattPeriode),
-                true, List.of(annenpartsPeriode), kontoer.build(),(LocalDateTime) null, null);
+                true, List.of(annenpartsPeriode), kontoer.build(), null, null, false);
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.restSaldoFlerbarnsdager(identifikator)).isEqualTo(new Trekkdager(16*5));
@@ -611,7 +612,7 @@ class SaldoUtregningTjenesteTest {
                         Utbetalingsgrad.HUNDRED))
                 .build();
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(fastsattPeriode), false,
-                List.of(annenpartPeriode1, annenpartPeriode2), kontoer.build(), (LocalDateTime) null, null);
+                List.of(annenpartPeriode1, annenpartPeriode2), kontoer.build(), null, null, false);
         var resultat = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
 
         assertThat(resultat.saldoITrekkdager(FELLESPERIODE, søkersArbeidsforhold)).isEqualTo(new Trekkdager(97));
@@ -651,7 +652,7 @@ class SaldoUtregningTjenesteTest {
         var grunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(opphold, uttakEtterOpphold), false,
                 List.of(annenpartUttaksperiode1, annenpartUttaksperiode2, annenpartUttaksperiode3), kontoer.build(),
                 LocalDateTime.of(annenpartUttaksperiode1.getFom(), LocalTime.NOON),
-                LocalDateTime.of(opphold.getFom(), LocalTime.NOON));
+                LocalDateTime.of(opphold.getFom(), LocalTime.NOON), true);
         var resultat = SaldoUtregningTjeneste.lagUtregning(grunnlag);
 
         //100 - 25 - 25 - 25 - 1
@@ -678,7 +679,7 @@ class SaldoUtregningTjenesteTest {
         var grunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(opphold, uttakEtterOpphold), false,
                 List.of(annenpartUttaksperiode), kontoer.build(),
                 LocalDateTime.of(annenpartUttaksperiode.getFom(), LocalTime.NOON),
-                LocalDateTime.of(opphold.getFom(), LocalTime.NOON));
+                LocalDateTime.of(opphold.getFom(), LocalTime.NOON), true);
         var resultat = SaldoUtregningTjeneste.lagUtregning(grunnlag);
 
         //100 - 3 - 2 - 1
@@ -710,11 +711,75 @@ class SaldoUtregningTjenesteTest {
         var grunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(opphold, uttakEtterOpphold), false,
                 List.of(annenpartUttaksperiode1, annenpartUttaksperiode2), kontoer.build(),
                 LocalDateTime.of(annenpartUttaksperiode1.getFom(), LocalTime.NOON),
-                LocalDateTime.of(opphold.getFom(), LocalTime.NOON));
+                LocalDateTime.of(opphold.getFom(), LocalTime.NOON), true);
         var resultat = SaldoUtregningTjeneste.lagUtregning(grunnlag);
 
         //100 - 2 - 2 - 1 - 1
         assertThat(resultat.saldo(FELLESPERIODE)).isEqualTo(94);
+    }
+
+    @Test
+    void oppholdsperioder_skal_ikke_telle_dager_ved_fritt_uttak() {
+        var opphold = new FastsattUttakPeriode.Builder()
+            .periodeResultatType(INNVILGET)
+            .oppholdÅrsak(OppholdÅrsak.FELLESPERIODE_ANNEN_FORELDER)
+            .tidsperiode(LocalDate.of(2022, 11, 4), LocalDate.of(2022, 11, 4))
+            .build();
+        var uttakEtterOpphold = new FastsattUttakPeriode.Builder().periodeResultatType(INNVILGET)
+            .tidsperiode(LocalDate.of(2022, 11, 7), LocalDate.of(2022, 11, 7))
+            .aktiviteter(List.of(new FastsattUttakPeriodeAktivitet(new Trekkdager(1), FELLESPERIODE, forFrilans())))
+            .build();
+
+        var annenpartOpphold = AnnenpartUttakPeriode.Builder.uttak(LocalDate.of(2022, 11, 8), LocalDate.of(2022, 11, 8))
+            .innvilget(true)
+            .oppholdsårsak(FELLESPERIODE_ANNEN_FORELDER)
+            .build();
+
+        var annenpartUttak = AnnenpartUttakPeriode.Builder.uttak(LocalDate.of(2022, 11, 9), LocalDate.of(2022, 11, 9))
+            .innvilget(true)
+            .uttakPeriodeAktivitet(
+                new AnnenpartUttakPeriodeAktivitet(forFrilans(), FELLESPERIODE, new Trekkdager(1), Utbetalingsgrad.FULL))
+            .build();
+
+        var kontoer = new Kontoer.Builder().konto(konto(FELLESPERIODE, 100)).build();
+
+        var grunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(opphold, uttakEtterOpphold), false,
+            List.of(annenpartOpphold, annenpartUttak), kontoer, null, null, false);
+        var resultat = SaldoUtregningTjeneste.lagUtregning(grunnlag);
+
+        assertThat(resultat.saldo(FELLESPERIODE)).isEqualTo(98);
+    }
+
+    @Test
+    void oppholdsperioder_skal_telle_dager_ved_sammehengende_uttak() {
+        var opphold = new FastsattUttakPeriode.Builder()
+            .periodeResultatType(INNVILGET)
+            .oppholdÅrsak(OppholdÅrsak.FELLESPERIODE_ANNEN_FORELDER)
+            .tidsperiode(LocalDate.of(2022, 11, 4), LocalDate.of(2022, 11, 4))
+            .build();
+        var uttakEtterOpphold = new FastsattUttakPeriode.Builder().periodeResultatType(INNVILGET)
+            .tidsperiode(LocalDate.of(2022, 11, 7), LocalDate.of(2022, 11, 7))
+            .aktiviteter(List.of(new FastsattUttakPeriodeAktivitet(new Trekkdager(1), FELLESPERIODE, forFrilans())))
+            .build();
+
+        var annenpartOpphold = AnnenpartUttakPeriode.Builder.uttak(LocalDate.of(2022, 11, 8), LocalDate.of(2022, 11, 8))
+            .innvilget(true)
+            .oppholdsårsak(FELLESPERIODE_ANNEN_FORELDER)
+            .build();
+
+        var annenpartUttak = AnnenpartUttakPeriode.Builder.uttak(LocalDate.of(2022, 11, 9), LocalDate.of(2022, 11, 9))
+            .innvilget(true)
+            .uttakPeriodeAktivitet(
+                new AnnenpartUttakPeriodeAktivitet(forFrilans(), FELLESPERIODE, new Trekkdager(1), Utbetalingsgrad.FULL))
+            .build();
+
+        var kontoer = new Kontoer.Builder().konto(konto(FELLESPERIODE, 100)).build();
+
+        var grunnlag = SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(List.of(opphold, uttakEtterOpphold), false,
+            List.of(annenpartOpphold, annenpartUttak), kontoer, null, null, true);
+        var resultat = SaldoUtregningTjeneste.lagUtregning(grunnlag);
+
+        assertThat(resultat.saldo(FELLESPERIODE)).isEqualTo(96);
     }
 
     private Konto.Builder konto(Stønadskontotype type, int dager) {

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ToParterOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ToParterOrkestreringTest.java
@@ -401,7 +401,7 @@ class ToParterOrkestreringTest extends FastsettePerioderRegelOrkestreringTestBas
                         annenpartPeriodeInnvilget(fødselsdato, fødselsdato.plusWeeks(6).minusDays(1), MØDREKVOTE, new Trekkdager(30)))
                         .uttaksperiode(annenpartPeriodeOpphold(fødselsdato.plusWeeks(6), fødselsdato.plusWeeks(8).minusDays(1),
                                 OppholdÅrsak.FEDREKVOTE_ANNEN_FORELDER)))
-                .behandling(farBehandling())
+                .behandling(farBehandling().kreverSammenhengendeUttak(true))
                 .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
                         .oppgittPeriode(
                                 oppgittPeriode(FEDREKVOTE, fødselsdato.plusWeeks(8), fødselsdato.plusWeeks(23).minusDays(1))));
@@ -520,7 +520,7 @@ class ToParterOrkestreringTest extends FastsettePerioderRegelOrkestreringTestBas
                                 forFrilans(), true))
                         .uttaksperiode(annenpartsPeriode(FELLESPERIODE, fødselsdato.plusWeeks(15), fødselsdato.plusWeeks(17),
                                 forFrilans(), true)))
-                .behandling(farBehandling())
+                .behandling(farBehandling().kreverSammenhengendeUttak(true))
                 .rettOgOmsorg(beggeRett())
                 .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
                         .oppgittPeriode(
@@ -557,7 +557,7 @@ class ToParterOrkestreringTest extends FastsettePerioderRegelOrkestreringTestBas
                         .uttaksperiode(annenpartsPeriode(MØDREKVOTE, fødselsdato, fødselsdato.plusWeeks(15).minusDays(1),
                                 forFrilans(), true))
                         .uttaksperiode(annenpartPeriodeUtenTrekkdager))
-                .behandling(farBehandling())
+                .behandling(farBehandling().kreverSammenhengendeUttak(true))
                 .rettOgOmsorg(beggeRett())
                 .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
                         .oppgittPeriode(


### PR DESCRIPTION
Var en tid mellom regelendringsdagen og fram til vi startet å filtere ut oppholdsperioder søknadsdialogen sendte inn, derfor ligger det en del uttak som inneholder oppholdsperioder selv om fritt uttak.
Filtrerer bort disse for å få saldoutregningen riktig, skal ikke trekke dager.

Eksempel fra prod 152098894