### PR TITLE
TFP-5757: Innvilget automatisk fellesperioder eller foreldrepenger so…

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/regelflyt/FellesperiodeDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/regelflyt/FellesperiodeDelregel.java
@@ -15,7 +15,6 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmS�
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmSøknadGjelderTerminEllerFødsel;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmTilgjengeligeDagerPåNoenAktiviteteneForSøktStønadskonto;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmUttakSkjerEtterDeFørsteUkene;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.SjekkOmUttakStarterFørUttakForForeldrepengerFørFødsel;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.betingelser.aktkrav.SjekkOmMorErIAktivitet;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.GraderingIkkeInnvilgetÅrsak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.IkkeOppfylt;
@@ -115,12 +114,12 @@ public class FellesperiodeDelregel implements RuleService<FastsettePeriodeGrunnl
                 .hvis(new SjekkOmPeriodenStarterFørLovligUttakFørFødselTermin(),
                         IkkeOppfylt.opprett("UT1040", IkkeOppfyltÅrsak.MOR_SØKER_FELLESPERIODE_FØR_12_UKER_FØR_TERMIN_FØDSEL, false,
                                 false))
-                .ellers(sjekkOmUttakStarterFørUttakForForeldrepengerFørFødsel());
+                .ellers(sjekkOmPeriodenStarterFørFamilieHendelse());
     }
 
-    private Specification<FastsettePeriodeGrunnlag> sjekkOmUttakStarterFørUttakForForeldrepengerFørFødsel() {
-        return rs.hvisRegel(SjekkOmUttakStarterFørUttakForForeldrepengerFørFødsel.ID, "Starter perioden før 3 uker før termin/fødsel?")
-                .hvis(new SjekkOmUttakStarterFørUttakForForeldrepengerFørFødsel(), sjekkOmGraderingIPerioden())
+    private Specification<FastsettePeriodeGrunnlag> sjekkOmPeriodenStarterFørFamilieHendelse() {
+        return rs.hvisRegel(SjekkOmPeriodenStarterFørFamiliehendelse.ID, SjekkOmPeriodenStarterFørFamiliehendelse.BESKRIVELSE)
+                .hvis(new SjekkOmPeriodenStarterFørFamiliehendelse(), sjekkOmGraderingIPerioden())
                 .ellers(sjekkOmUttakSkjerEtterDeFørsteUkene());
     }
 

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/regelflyt/ForeldrepengerDelregel.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/regelflyt/ForeldrepengerDelregel.java
@@ -142,11 +142,11 @@ public class ForeldrepengerDelregel implements RuleService<FastsettePeriodeGrunn
     }
 
     private Specification<FastsettePeriodeGrunnlag> sjekkOmPeriodenStarterFørFamilieHendelse() {
-        var erDetBareMorSomHarRettSjekk = erDetAleneomsorgSjekk(
-            Manuellbehandling.opprett("UT1197", null, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO, true, true),
-            Manuellbehandling.opprett("UT1192", null, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO, true, true));
+        var sjekkErDetAleneomsorg = erDetAleneomsorgSjekk(
+            Oppfylt.opprett("UT1197", InnvilgetÅrsak.FORELDREPENGER_ALENEOMSORG, true, true),
+            Oppfylt.opprett("UT1192", InnvilgetÅrsak.FORELDREPENGER_KUN_MOR_HAR_RETT, true, true));
         return rs.hvisRegel(SjekkOmPeriodenStarterFørFamiliehendelse.ID, "Starter perioden før termin/fødsel?")
-                .hvis(new SjekkOmPeriodenStarterFørFamiliehendelse(), erDetBareMorSomHarRettSjekk)
+                .hvis(new SjekkOmPeriodenStarterFørFamiliehendelse(), sjekkErDetAleneomsorg)
                 .ellers(sjekkErPeriodenInnenforUkerReservertMor());
     }
 

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeDelregelTest.java
@@ -56,8 +56,8 @@ class FellesperiodeDelregelTest {
     }
 
     @Test
-    void fellesperiode_mor_uttak_starter_ved_3_uker_før_fødsel_slutter_før_7_uker_blir_avslått() {
-        var søknadsperiode = oppgittPeriode(fødselsdato.minusWeeks(3), fødselsdato.plusWeeks(3), null, false);
+    void fellesperiode_mor_uttak_starter_etter_fødsel_og_som_slutter_før_7_uker_blir_avslått() {
+        var søknadsperiode = oppgittPeriode(fødselsdato, fødselsdato.plusWeeks(3), null, false);
         var kontoer = enFellesperiodeKonto(13 * 5);
         var grunnlag = basicGrunnlagMor().søknad(søknad(søknadsperiode))
                 .arbeid(new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(ARBEIDSFORHOLD_1)))
@@ -70,7 +70,7 @@ class FellesperiodeDelregelTest {
     }
 
     @Test
-    void fellesperiode_mor_uttak_starter_ved_3_uker_før_fødsel_slutter_før_fødsel_blir_avslått() {
+    void fellesperiode_mor_uttak_starter_ved_3_uker_før_fødsel_slutter_før_fødsel_blir_innvilget() {
         var søknadsperiode = oppgittPeriode(fødselsdato.minusWeeks(3), fødselsdato.minusWeeks(1), null, false);
         var kontoer = enFellesperiodeKonto(13 * 5);
         var grunnlag = basicGrunnlagMor().søknad(søknad(søknadsperiode))
@@ -80,7 +80,7 @@ class FellesperiodeDelregelTest {
 
         var regelresultat = kjørRegel(søknadsperiode, grunnlag);
 
-        assertThat(regelresultat.oppfylt()).isFalse();
+        assertThat(regelresultat.oppfylt()).isTrue();
     }
 
     @Test

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FellesperiodeOrkestreringTest.java
@@ -98,7 +98,7 @@ class FellesperiodeOrkestreringTest extends FastsettePerioderRegelOrkestreringTe
     }
 
     @Test
-    void fellesperiode_mor_uttak_starter_ved_12_uker_og_slutter_etter_3_uker_før_fødsel_blir_innvilget_med_knekk_ved_3_uker_resten_blir_manuell_behandling() {
+    void fellesperiode_mor_uttak_starter_ved_12_uker_og_slutter_etter_3_uker_før_fødsel_og_blir_innvilget() {
         var kontoer = new Kontoer.Builder().konto(new Konto.Builder().type(FORELDREPENGER_FØR_FØDSEL).trekkdager(3 * 5))
                 .konto(new Konto.Builder().type(MØDREKVOTE).trekkdager(15 * 5))
                 .konto(new Konto.Builder().type(FELLESPERIODE).trekkdager(16 * 5));
@@ -115,8 +115,8 @@ class FellesperiodeOrkestreringTest extends FastsettePerioderRegelOrkestreringTe
         assertThat(resultater).hasSize(4);
         verifiserPeriode(resultater.get(0).uttakPeriode(), fødselsdato.minusWeeks(12), fødselsdato.minusWeeks(3).minusDays(1),
                 Perioderesultattype.INNVILGET, FELLESPERIODE);
-        verifiserManuellBehandlingPeriode(resultater.get(1).uttakPeriode(), fødselsdato.minusWeeks(3),
-                fødselsdato.minusWeeks(1).minusDays(1), FELLESPERIODE, null, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO);
+        verifiserPeriode(resultater.get(1).uttakPeriode(), fødselsdato.minusWeeks(3), fødselsdato.minusWeeks(1).minusDays(1),
+            Perioderesultattype.INNVILGET, FELLESPERIODE);
         verifiserPeriode(resultater.get(2).uttakPeriode(), fødselsdato.minusWeeks(1), fødselsdato.minusDays(1),
                 Perioderesultattype.INNVILGET, FORELDREPENGER_FØR_FØDSEL);
         verifiserPeriode(resultater.get(3).uttakPeriode(), fødselsdato, fødselsdato.plusWeeks(6).minusDays(1),
@@ -159,8 +159,8 @@ class FellesperiodeOrkestreringTest extends FastsettePerioderRegelOrkestreringTe
                 Perioderesultattype.AVSLÅTT, Stønadskontotype.FELLESPERIODE);
         verifiserPeriode(resultater.get(1).uttakPeriode(), fødselsdato.minusWeeks(12), fødselsdato.minusWeeks(3).minusDays(1),
                 Perioderesultattype.INNVILGET, Stønadskontotype.FELLESPERIODE);
-        verifiserManuellBehandlingPeriode(resultater.get(2).uttakPeriode(), fødselsdato.minusWeeks(3), fødselsdato.minusDays(1),
-                FELLESPERIODE, null, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO);
+        verifiserPeriode(resultater.get(2).uttakPeriode(), fødselsdato.minusWeeks(3), fødselsdato.minusDays(1),
+            Perioderesultattype.INNVILGET, Stønadskontotype.FELLESPERIODE);
         verifiserManuellBehandlingPeriode(resultater.get(3).uttakPeriode(), fødselsdato, fødselsdato, FELLESPERIODE, null,
                 Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO);
         verifiserAvslåttPeriode(resultater.get(4).uttakPeriode(), fødselsdato.plusDays(1), fødselsdato.plusWeeks(6).minusDays(3),

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ForeldrepengerDelregelTest.java
@@ -289,7 +289,7 @@ class ForeldrepengerDelregelTest {
 
         var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
 
-        assertManuellBehandling(regelresultat, null, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO, true, true);
+        assertInnvilget(regelresultat, InnvilgetÅrsak.FORELDREPENGER_KUN_MOR_HAR_RETT, "UT1192");
     }
 
     @Test
@@ -306,7 +306,7 @@ class ForeldrepengerDelregelTest {
 
         var regelresultat = kjørRegel(oppgittPeriode, grunnlag);
 
-        assertManuellBehandling(regelresultat, null, Manuellbehandlingårsak.UGYLDIG_STØNADSKONTO, true, true);
+        assertInnvilget(regelresultat, InnvilgetÅrsak.FORELDREPENGER_ALENEOMSORG, "UT1197");
     }
 
     private void assertManuellBehandling(FastsettePerioderRegelresultat regelresultat,


### PR DESCRIPTION
…m havner innenfor intervallet [F-3U, F-1D]

Dette er løsning for https://jira.adeo.no/browse/TFP-5757 som angår fellesperiode/foreldrepenger som havner innenfor de ukene forbeholdt FORELDREPENGER_FØR_FØDSEL. Marte mente at alternativ 1 var mest sannsynlig. Hun skal komme med faglig avklaring på det før denne kan merges.

**Løsningen:** Vi kan ikke innvilge mer FFF enn det som i utgangspunktet er søkt om. Men vi kan automatisk innvilge disse periodene i uttaksreglene dersom det ligger fellesperioden eller foreldrepenger i dette intervallet.