### PR TITLE
Forenkle oppsett i orkestrering/resultatbehandling

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlagImpl.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/FastsettePeriodeGrunnlagImpl.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.regler.uttak.fastsetteperiode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -133,7 +132,7 @@ public class FastsettePeriodeGrunnlagImpl implements FastsettePeriodeGrunnlag {
 
     @Override
     public List<AnnenpartUttakPeriode> getAnnenPartUttaksperioder() {
-        return regelGrunnlag.getAnnenPart() != null ? regelGrunnlag.getAnnenPart().getUttaksperioder() : Collections.emptyList();
+        return regelGrunnlag.getAnnenpartUttaksperioder();
     }
 
     @Override

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/RegelGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/grunnlag/RegelGrunnlag.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.ytelser.Ytelser;
@@ -58,6 +60,10 @@ public class RegelGrunnlag {
 
     public AnnenPart getAnnenPart() {
         return annenPart;
+    }
+
+    public List<AnnenpartUttakPeriode> getAnnenpartUttaksperioder() {
+        return Optional.ofNullable(getAnnenPart()).map(AnnenPart::getUttaksperioder).orElseGet(List::of);
     }
 
     public Medlemskap getMedlemskap() {

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifiserer.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifiserer.java
@@ -35,15 +35,12 @@ public class TomKontoIdentifiserer {
                                                            SaldoUtregning saldoUtregning,
                                                            Stønadskontotype stønadskontotype,
                                                            LukketPeriode farRundtFødselIntervall,
-                                                           LocalDate startdatoNesteStønadsperiode,
+                                                           boolean etterNesteStønadsperiode,
                                                            boolean skalTrekkeDager,
                                                            PeriodeResultatÅrsak periodeResultatÅrsak,
                                                            UtfallType utfallType) {
 
         Map<LocalDate, TomKontoKnekkpunkt> knekkpunkter = new HashMap<>();
-        var etterNesteStønadsperiode = Optional.ofNullable(startdatoNesteStønadsperiode)
-            .filter(d -> !uttakPeriode.getFom().isBefore(d))
-            .isPresent(); // Om aktuell periode begynner fom neste stønadsperiode
         for (var aktivitet : aktiviteter) {
             var datoKontoGårTomIPeriode = finnDatoKontoGårTomIPeriode(uttakPeriode, aktivitet, saldoUtregning, stønadskontotype, skalTrekkeDager);
             datoKontoGårTomIPeriode.ifPresent(dato -> knekkpunkter.put(dato, new TomKontoKnekkpunkt(dato)));

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/util/SamtidigUttakUtil.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/util/SamtidigUttakUtil.java
@@ -13,7 +13,6 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeGrunn
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AnnenpartUttakPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AnnenpartUttakPeriodeAktivitet;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.RegelGrunnlag;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.SamtidigUttaksprosent;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Utbetalingsgrad;
@@ -88,9 +87,9 @@ public final class SamtidigUttakUtil {
             app -> app.erOmsluttetAv(farRundtFødselIntervall)).isPresent();
     }
 
-    public static boolean kanRedusereUtbetalingsgradForTapende(FastsettePeriodeGrunnlag periodeGrunnlag, RegelGrunnlag regelGrunnlag) {
+    public static boolean kanRedusereUtbetalingsgradForTapende(FastsettePeriodeGrunnlag periodeGrunnlag) {
         // Er det ikkejusterbar periode, samtidig uttak under 100% eller 150/200% tilfelle?
-        var kanReduseres = regelGrunnlag.getBehandling().isBerørtBehandling() || erTapendePeriodeUtregning(periodeGrunnlag);
+        var kanReduseres = periodeGrunnlag.isBerørtBehandling() || erTapendePeriodeUtregning(periodeGrunnlag);
         if (!kanReduseres || !annenpartHarSamtidigPeriodeMedUtbetaling(periodeGrunnlag) || !merEnn100ProsentSamtidigUttak(periodeGrunnlag)
             || akseptert200ProsentSamtidigUttak(periodeGrunnlag) || akseptert150ProsentSamtidigUttak(periodeGrunnlag)) {
             return false;

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/RegelResultatBehandlerTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/RegelResultatBehandlerTest.java
@@ -43,11 +43,13 @@ class RegelResultatBehandlerTest {
         var knekkpunkt = new TomKontoKnekkpunkt(LocalDate.of(2018, 10, 15));
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(), List.of(), grunnlag, oppgittPeriode.getFom());
         oppgittPeriode.setAktiviteter(Set.of(arbeidsforhold.identifikator()));
-        var behandler = new RegelResultatBehandler(SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag), grunnlag);
+        var fastsettePeriodeGrunnlag = new FastsettePeriodeGrunnlagImpl(grunnlag, null,
+            SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag), oppgittPeriode);
+        var behandler = new RegelResultatBehandler(fastsettePeriodeGrunnlag);
 
         var regelresultat = new FastsettePerioderRegelresultat(null,
             UttakOutcome.ikkeOppfylt(IkkeOppfyltÅrsak.IKKE_STØNADSDAGER_IGJEN).medTrekkDagerFraSaldo(true));
-        var resultat = behandler.avslåAktuellPeriode(oppgittPeriode, regelresultat, Optional.of(knekkpunkt), false);
+        var resultat = behandler.avslåAktuellPeriode(oppgittPeriode, regelresultat, Optional.of(knekkpunkt));
 
         assertThat(resultat.getPeriode().getFom()).isEqualTo(fom);
         assertThat(resultat.getPeriode().getTom()).isEqualTo(knekkpunkt.dato().minusDays(1));

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifisererTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/utfall/TomKontoIdentifisererTest.java
@@ -68,7 +68,7 @@ class TomKontoIdentifisererTest {
         var saldoUtregningGrunnlag = SaldoUtregningGrunnlag.forUtregningAvDelerAvUttak(List.of(), List.of(), grunnlag, oppgittPeriode.getFom());
         var saldoUtregning = SaldoUtregningTjeneste.lagUtregning(saldoUtregningGrunnlag);
         var tomKontoKnekkpunkt = TomKontoIdentifiserer.identifiser(oppgittPeriode, List.of(ARBEIDSFORHOLD_1), saldoUtregning,
-            Stønadskontotype.MØDREKVOTE, null, null, true, InnvilgetÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE, UtfallType.INNVILGET);
+            Stønadskontotype.MØDREKVOTE, null, false, true, InnvilgetÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE, UtfallType.INNVILGET);
         assertThat(tomKontoKnekkpunkt.orElseThrow().dato()).isEqualTo(Virkedager.plusVirkedager(idag, virkedagerVarighet));
     }
 }


### PR DESCRIPTION
Hovedsaken er å bruke FastsettePeriodeGrunnlag så langt som mulig og unngå å sende rundt RegelGrunnlag og SaldoUtregning
Dette er fase1. Jobber videre med å ta inn Espens branch senere - etter runde med kreverSammenhengendeUttak.