### PR TITLE
FAGSYSTEM-426838 fikser bug der ikke trekkdager settes på avslag utse…

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ValgAvStønadskontoTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ValgAvStønadskontoTjeneste.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktivitetIdentifikator;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.UtsettelseÅrsak;
@@ -41,7 +42,7 @@ final class ValgAvStønadskontoTjeneste {
 
     private static Optional<Stønadskontotype> velg(FastsettePeriodeGrunnlag fastsettePeriodeGrunnlag) {
         for (var stønadskontotype : hentSøkerSineKontoer(fastsettePeriodeGrunnlag)) {
-            if (!erTomForKonto(fastsettePeriodeGrunnlag.getAktuellPeriode(), stønadskontotype, fastsettePeriodeGrunnlag.getSaldoUtregning())) {
+            if (harDagerPåKonto(fastsettePeriodeGrunnlag.getAktuellPeriode(), stønadskontotype, fastsettePeriodeGrunnlag.getSaldoUtregning())) {
                 return Optional.of(stønadskontotype);
             }
         }
@@ -83,10 +84,15 @@ final class ValgAvStønadskontoTjeneste {
         return søkerSineKonto;
     }
 
-    private static boolean erTomForKonto(OppgittPeriode periode, Stønadskontotype stønadskontotype, SaldoUtregning saldoUtregning) {
-        return !periode.getAktiviteter().isEmpty() && periode.getAktiviteter().stream().allMatch(arbeidsforhold -> {
-            var saldo = saldoUtregning.nettoSaldoJustertForMinsterett(stønadskontotype, arbeidsforhold, periode.kanTrekkeAvMinsterett());
-            return !saldo.merEnn0();
-        });
+    private static boolean harDagerPåKonto(OppgittPeriode periode, Stønadskontotype stønadskontotype, SaldoUtregning saldoUtregning) {
+        return periode.getAktiviteter().stream().anyMatch(a -> harAktivitetDagerPåKonto(periode, stønadskontotype, saldoUtregning, a));
+      }
+
+    private static boolean harAktivitetDagerPåKonto(OppgittPeriode periode,
+                                                    Stønadskontotype stønadskontotype,
+                                                    SaldoUtregning saldoUtregning,
+                                                    AktivitetIdentifikator arbeidsforhold) {
+        var saldo = saldoUtregning.nettoSaldoJustertForMinsterett(stønadskontotype, arbeidsforhold, periode.kanTrekkeAvMinsterett());
+        return saldo.merEnn0();
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ValgAvStønadskontoTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/ValgAvStønadskontoTjeneste.java
@@ -84,17 +84,9 @@ final class ValgAvStønadskontoTjeneste {
     }
 
     private static boolean erTomForKonto(OppgittPeriode periode, Stønadskontotype stønadskontotype, SaldoUtregning saldoUtregning) {
-        var tomForKonto = true;
-        for (var arbeidsforhold : periode.getAktiviteter()) {
+        return !periode.getAktiviteter().isEmpty() && periode.getAktiviteter().stream().allMatch(arbeidsforhold -> {
             var saldo = saldoUtregning.nettoSaldoJustertForMinsterett(stønadskontotype, arbeidsforhold, periode.kanTrekkeAvMinsterett());
-            if (saldo.merEnn0()) {
-                tomForKonto = false;
-            } else {
-                tomForKonto = true;
-                break;
-            }
-        }
-        return tomForKonto;
+            return !saldo.merEnn0();
+        });
     }
-
 }

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/MinsterettOrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/MinsterettOrkestreringTest.java
@@ -525,6 +525,59 @@ class MinsterettOrkestreringTest extends FastsettePerioderRegelOrkestreringTestB
         assertThat(fastsattePerioder.get(3).uttakPeriode().getPeriodeResultatÅrsak()).isEqualTo(FORELDREPENGER_KUN_FAR_HAR_RETT_UTEN_AKTIVITETSKRAV);
     }
 
+    @Test
+    void bfhr_gradering_to_arbeidsforhold_fri_utsettelse_skal_sette_riktig_dager_i_begge_arbeidsforhold() {
+        var fødselsdato = Virkedager.justerHelgTilMandag(LocalDate.of(2023, 3, 15));
+        var kontoer = new Kontoer.Builder().konto(konto(FORELDREPENGER, 200)).minsterettDager(40);
+        var arbeidsforhold1 = AktivitetIdentifikator.forArbeid(new Orgnummer("1"), null);
+        var arbeidsforhold2 = AktivitetIdentifikator.forArbeid(new Orgnummer("2"), null);
+
+        var gradering = OppgittPeriode.forGradering(FORELDREPENGER, LocalDate.of(2023, 3, 29), LocalDate.of(2023, 6, 9), BigDecimal.valueOf(50), null,
+            false, Set.of(arbeidsforhold1), fødselsdato, fødselsdato, SYK, null, MORS_AKTIVITET_GODKJENT);
+
+        var utsettelse = OppgittPeriode.forUtsettelse(LocalDate.of(2023, 6, 12), LocalDate.of(2025, 9, 9), FRI, fødselsdato, fødselsdato, null, null);
+
+        var søknad = new Søknad.Builder().type(Søknadstype.FØDSEL).oppgittePerioder(List.of(gradering, utsettelse));
+
+        var arbeid = new Arbeid.Builder().arbeidsforhold(new Arbeidsforhold(arbeidsforhold1)).arbeidsforhold(new Arbeidsforhold(arbeidsforhold2));
+        var grunnlag = basicGrunnlagFar(fødselsdato).rettOgOmsorg(bareFarRett()).søknad(søknad).arbeid(arbeid).kontoer(kontoer);
+        var fastsattePerioder = fastsettPerioder(grunnlag);
+
+
+        assertThat(fastsattePerioder).hasSize(5);
+        var resultatperiode1 = fastsattePerioder.getFirst().uttakPeriode();
+        var resultatperiode2 = fastsattePerioder.get(1).uttakPeriode();
+        var resultatperiode3 = fastsattePerioder.get(2).uttakPeriode();
+        var resultatperiode4 = fastsattePerioder.get(3).uttakPeriode();
+        var resultatperiode5 = fastsattePerioder.get(4).uttakPeriode();
+
+        assertThat(resultatperiode1.getPerioderesultattype()).isEqualTo(Perioderesultattype.INNVILGET);
+        assertThat(resultatperiode1.getUtbetalingsgrad(arbeidsforhold1)).isEqualTo(new Utbetalingsgrad(50));
+        assertThat(resultatperiode1.getUtbetalingsgrad(arbeidsforhold2)).isEqualTo(Utbetalingsgrad.FULL);
+
+        assertThat(resultatperiode2.getPerioderesultattype()).isEqualTo(Perioderesultattype.INNVILGET);
+        assertThat(resultatperiode2.getUtbetalingsgrad(arbeidsforhold1)).isEqualTo(new Utbetalingsgrad(50));
+        assertThat(resultatperiode2.getUtbetalingsgrad(arbeidsforhold2)).isEqualTo(Utbetalingsgrad.FULL);
+
+        assertThat(resultatperiode3.getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
+        assertThat(resultatperiode3.getUtbetalingsgrad(arbeidsforhold1)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(resultatperiode3.getUtbetalingsgrad(arbeidsforhold2)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(resultatperiode3.getTrekkdager(arbeidsforhold1)).isEqualTo(new Trekkdager(107));
+        assertThat(resultatperiode3.getTrekkdager(arbeidsforhold2)).isEqualTo(new Trekkdager(107));
+
+        assertThat(resultatperiode4.getPerioderesultattype()).isEqualTo(Perioderesultattype.AVSLÅTT);
+        assertThat(resultatperiode4.getUtbetalingsgrad(arbeidsforhold1)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(resultatperiode4.getUtbetalingsgrad(arbeidsforhold2)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(resultatperiode4.getTrekkdager(arbeidsforhold1)).isEqualTo(new Trekkdager(27)); //Har igjen dager pga gradering
+        assertThat(resultatperiode4.getTrekkdager(arbeidsforhold2)).isEqualTo(Trekkdager.ZERO); //Brukt opp dager, bare minsterett igjen for dette arbeidsforholdet
+
+        assertThat(resultatperiode5.getPerioderesultattype()).isEqualTo(Perioderesultattype.INNVILGET); //Bare minsterett gjenværende, kan ikke trekke noe derfor innvilges utsettelse
+        assertThat(resultatperiode5.getUtbetalingsgrad(arbeidsforhold1)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(resultatperiode5.getUtbetalingsgrad(arbeidsforhold2)).isEqualTo(Utbetalingsgrad.ZERO);
+        assertThat(resultatperiode5.getTrekkdager(arbeidsforhold1)).isEqualTo(Trekkdager.ZERO);
+        assertThat(resultatperiode5.getTrekkdager(arbeidsforhold2)).isEqualTo(Trekkdager.ZERO);
+    }
+
     private static OppgittPeriode friUtsettelse(LocalDate fom, LocalDate tom) {
         return OppgittPeriode.forUtsettelse(fom, tom, FRI, fom, fom, null, null);
     }

--- a/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/OrkestreringTest.java
+++ b/src/test/java/no/nav/foreldrepenger/regler/uttak/fastsetteperiode/OrkestreringTest.java
@@ -39,7 +39,6 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Behandling;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Datoer;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.DokumentasjonVurdering;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Dødsdatoer;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.EndringAvStilling;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.FastsattUttakPeriodeAktivitet;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Konto;
@@ -802,33 +801,6 @@ class OrkestreringTest extends FastsettePerioderRegelOrkestreringTestBase {
         //første søkte
         assertThat(resultat.get(2).uttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(Trekkdager.ZERO);
         assertThat(resultat.get(2).uttakPeriode().getStønadskontotype()).isEqualTo(FORELDREPENGER);
-    }
-
-    @Test
-    void utsettelse_som_går_til_manuell_behandling_skal_ikke_trekke_dager_hvis_dager_igjen_på_bare_ett_av_to_arbeidsforhold_selv_om_sluttpunkt_trekker_dager() {
-        var fødselsdato = LocalDate.of(2018, 6, 14);
-        var arbeidsforhold1 = new Arbeidsforhold(ARBEIDSFORHOLD_1);
-        var arbeidsforhold2 = new Arbeidsforhold(ARBEIDSFORHOLD_2);
-        var grunnlag = basicGrunnlag(fødselsdato).behandling(morBehandling().sammenhengendeUttakTomDato(LocalDate.of(9999, 1, 1)))
-            .rettOgOmsorg(aleneomsorg())
-            //50% prosent stilling, men søker utsettelse. Går til manuell behandling
-            .arbeid(new Arbeid.Builder().arbeidsforhold(arbeidsforhold1)
-                .arbeidsforhold(arbeidsforhold2)
-                .endringAvStilling(new EndringAvStilling(fødselsdato, BigDecimal.valueOf(75))))
-            .søknad(new Søknad.Builder().type(Søknadstype.FØDSEL)
-                .oppgittPeriode(oppgittPeriode(FORELDREPENGER, fødselsdato, fødselsdato.plusWeeks(6).minusDays(1)))
-                .oppgittPeriode(
-                    gradertoppgittPeriode(FORELDREPENGER, fødselsdato.plusWeeks(6), fødselsdato.plusWeeks(7).minusDays(1), BigDecimal.valueOf(50),
-                        Set.of(arbeidsforhold1.identifikator())))
-                .oppgittPeriode(utsettelsePeriode(fødselsdato.plusWeeks(7), fødselsdato.plusWeeks(100), UtsettelseÅrsak.ARBEID, null)))
-            .kontoer(new Kontoer.Builder().konto(konto(FORELDREPENGER, 35)));
-
-        var resultat = fastsettPerioder(grunnlag);
-        assertThat(resultat).hasSize(3);
-        assertThat(resultat.get(2).uttakPeriode().getManuellbehandlingårsak()).isNotNull();
-        assertThat(resultat.get(2).uttakPeriode().getTrekkdager(ARBEIDSFORHOLD_1)).isEqualTo(Trekkdager.ZERO);
-        assertThat(resultat.get(2).uttakPeriode().getTrekkdager(ARBEIDSFORHOLD_2)).isEqualTo(Trekkdager.ZERO);
-        assertThat(resultat.get(2).uttakPeriode().getStønadskontotype()).isNull();
     }
 
     @Test


### PR DESCRIPTION
…ttelser ved flere arbeidsforhold, og der gradering gjør at gjenværende dager er ulik for arbeidsforholdene

Den testen(og funksjonaliteten) jeg fjernet synes jeg ikke gir mening nå. Den ble innført tidligere pga at det ga taskfeil, men dette håndteres nå. Ser ikke helt poenget nå med fri utsettelse heller.

Endringer består av å endre logikken som utleder hvilken konto avslått utsettelse skal trekke fra. Her så man tidligere bare at det minst en av arbeidsforholdene var tom for dager (og dermed ingen trekkdager på noen av aktivitetene). Endrer til at alle arbeidsforholdene må være tomme for at ikke kontotype for utsettelsen utledes